### PR TITLE
flho-170 Authority holders name step.

### DIFF
--- a/apps/new-dealer/acceptance/features/first-authority-holders-name.js
+++ b/apps/new-dealer/acceptance/features/first-authority-holders-name.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const steps = require('../../');
+
+Feature('First authority holders name step');
+
+Before((
+  I,
+  firstAuthorityHoldersNamePage
+) => {
+  I.visitPage(firstAuthorityHoldersNamePage, steps);
+});
+
+Scenario('The correct form elements are present', (
+  I,
+  firstAuthorityHoldersNamePage
+) => {
+  I.seeElement(firstAuthorityHoldersNamePage['holders-name']);
+});
+
+Scenario('An error is shown if first-authority-holders-name step is not completed', (
+  I,
+  firstAuthorityHoldersNamePage
+) => {
+  I.submitForm();
+  I.seeErrors(firstAuthorityHoldersNamePage['holders-name']);
+});
+
+Scenario('When I select one on the authority-holders step I see the one authority holder translations', function *(
+  I,
+  firstAuthorityHoldersNamePage
+) {
+  yield I.setSessionData(steps.name, {
+    'authority-holders': 'one'
+  });
+  yield I.refreshPage();
+  firstAuthorityHoldersNamePage.pageShowsCorrectAuthorityTranslations('one');
+});
+
+Scenario('When I select two on the authority-holders step I see the two authority holder translations', function *(
+  I,
+  firstAuthorityHoldersNamePage
+) {
+  yield I.setSessionData(steps.name, {
+    'authority-holders': 'two'
+  });
+  yield I.refreshPage();
+  firstAuthorityHoldersNamePage.pageShowsCorrectAuthorityTranslations('two');
+});
+
+Scenario('Im taken to the first-authority-holders-birth step', (
+  I,
+  firstAuthorityHoldersNamePage,
+  firstAuthorityHoldersBirthPage
+) => {
+  firstAuthorityHoldersNamePage.fillFormAndSubmit();
+  I.seeInCurrentUrl(firstAuthorityHoldersBirthPage.url);
+});

--- a/apps/new-dealer/acceptance/features/second-authority-holders-name.js
+++ b/apps/new-dealer/acceptance/features/second-authority-holders-name.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const steps = require('../../');
+
+Feature('Second authority holders name step');
+
+Before((
+  I,
+  secondAuthorityHoldersNamePage
+) => {
+  I.visitPage(secondAuthorityHoldersNamePage, steps);
+});
+
+Scenario('The correct form elements are present', (
+  I,
+  secondAuthorityHoldersNamePage
+) => {
+  I.seeElement(secondAuthorityHoldersNamePage['holders-name']);
+});
+
+Scenario('An error is shown if second-authority-holders-name step is not completed', (
+  I,
+  secondAuthorityHoldersNamePage
+) => {
+  I.submitForm();
+  I.seeErrors(secondAuthorityHoldersNamePage['holders-name']);
+});
+
+Scenario('Im taken to the second-authority-holders-birth step', (
+  I,
+  secondAuthorityHoldersNamePage,
+  secondAuthorityHoldersBirthPage
+) => {
+  secondAuthorityHoldersNamePage.fillFormAndSubmit();
+  I.seeInCurrentUrl(secondAuthorityHoldersBirthPage.url);
+});

--- a/apps/new-dealer/acceptance/pages/first-authority-holders-birth.js
+++ b/apps/new-dealer/acceptance/pages/first-authority-holders-birth.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  url: 'first-authority-holders-birth'
+};

--- a/apps/new-dealer/acceptance/pages/first-authority-holders-name.js
+++ b/apps/new-dealer/acceptance/pages/first-authority-holders-name.js
@@ -1,5 +1,32 @@
 'use strict';
 
+const TRANSLATIONS = require('../../translations/en/default');
+const FIELDS = TRANSLATIONS.fields;
+const PAGES = TRANSLATIONS.pages;
+
+let I;
+
 module.exports = {
-  url: 'first-authority-holders-name'
+
+  _init() {
+    I = require('so-acceptance/steps.js')();
+  },
+
+  url: 'first-authority-holders-name',
+  'holders-name': '#first-authority-holders-name',
+  content: {
+    'holders-name': 'Sterling Archer'
+  },
+
+  pageShowsCorrectAuthorityTranslations(authorityHolder){
+    I.seeEach([
+      PAGES['first-authority-holders-name'].header['authority-holders'][authorityHolder],
+      FIELDS['first-authority-holders-name'].label['authority-holders'][authorityHolder]
+    ])
+  },
+
+  fillFormAndSubmit(){
+    I.fillField(this['holders-name'], this.content['holders-name']);
+    I.submitForm();
+  }
 };

--- a/apps/new-dealer/acceptance/pages/second-authority-holders-birth.js
+++ b/apps/new-dealer/acceptance/pages/second-authority-holders-birth.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  url: 'second-authority-holders-birth'
+};

--- a/apps/new-dealer/acceptance/pages/second-authority-holders-name.js
+++ b/apps/new-dealer/acceptance/pages/second-authority-holders-name.js
@@ -1,0 +1,21 @@
+'use strict';
+
+let I;
+
+module.exports = {
+
+  _init() {
+    I = require('so-acceptance/steps.js')();
+  },
+
+  url: 'second-authority-holders-name',
+  'holders-name': '#second-authority-holders-name',
+  content: {
+    'holders-name': 'Barry Dylan'
+  },
+
+  fillFormAndSubmit(){
+    I.fillField(this['holders-name'], this.content['holders-name']);
+    I.submitForm();
+  }
+};

--- a/apps/new-dealer/fields/index.js
+++ b/apps/new-dealer/fields/index.js
@@ -415,5 +415,13 @@ module.exports = {
       'one',
       'two'
     ]
+  },
+  'first-authority-holders-name': {
+    mixin: 'input-text',
+    validate: 'required'
+  },
+  'second-authority-holders-name': {
+    mixin: 'input-text',
+    validate: 'required'
   }
 };

--- a/apps/new-dealer/index.js
+++ b/apps/new-dealer/index.js
@@ -131,6 +131,49 @@ module.exports = {
       }
     },
     '/first-authority-holders-name': {
+      fields: [
+        'first-authority-holders-name'
+      ],
+      next: '/first-authority-holders-birth',
+      locals: {
+        section: 'first-authority-holders-name'
+      }
+    },
+    '/first-authority-holders-birth': {
+      next: '/first-authority-holders-nationality'
+    },
+    '/first-authority-holders-nationality': {
+      next: '/first-authority-holders-address'
+    },
+    '/first-authority-holders-address': {
+      next: '/contact',
+      forks: [{
+        target: '/second-authority-holders-name',
+        condition(req) {
+          return req.sessionModel.get('authority-holders') === 'two';
+        }
+      }]
+    },
+    '/second-authority-holders-name': {
+      fields: [
+        'second-authority-holders-name'
+      ],
+      next: '/second-authority-holders-birth',
+      locals: {
+        section: 'second-authority-holders-name'
+      }
+    },
+    '/second-authority-holders-birth': {
+      next: '/second-authority-holders-nationality'
+    },
+    '/second-authority-holders-nationality': {
+      next: '/second-authority-holders-address'
+    },
+    '/second-authority-holders-address': {
+      next: '/contact'
+    },
+    '/contact': {
+
     }
   }
 };

--- a/apps/new-dealer/translations/src/en/fields.json
+++ b/apps/new-dealer/translations/src/en/fields.json
@@ -340,5 +340,16 @@
         "label": "Two"
       }
     }
+  },
+  "first-authority-holders-name": {
+    "label": {
+      "authority-holders": {
+        "one": "Authority holder",
+        "two": "First authority holder"
+      }
+    }
+  },
+  "second-authority-holders-name": {
+    "label": "Second authority holder"
   }
 }

--- a/apps/new-dealer/translations/src/en/pages.json
+++ b/apps/new-dealer/translations/src/en/pages.json
@@ -60,5 +60,16 @@
   },
   "authority-holders": {
     "header": "How many individuals will be named on the authority?"
+  },
+  "first-authority-holders-name": {
+    "header": {
+      "authority-holders": {
+        "one": "What's the full name of the authority holder?",
+        "two": "What's the full name of the first authority holder?"
+      }
+    }
+  },
+  "second-authority-holders-name": {
+    "header": "What's the full name of the second authority holder?"
   }
 }

--- a/apps/new-dealer/translations/src/en/validation.json
+++ b/apps/new-dealer/translations/src/en/validation.json
@@ -120,5 +120,16 @@
   },
   "authority-holders": {
     "required": "Select an option"
+  },
+  "first-authority-holders-name": {
+    "required": {
+      "authority-holders": {
+        "one": "Enter the full name of the authority holder",
+        "two": "Enter the full name of the first authority holder"
+      }
+    }
+  },
+  "second-authority-holders-name": {
+    "required": "Enter the full name of the second authority holder"
   }
 }

--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -18,6 +18,9 @@ module.exports = {
     weaponsPage: pagesPath('weapons.js'),
     ammunitionsPage: pagesPath('ammunition.js'),
     authorityHoldersPage: pagesPath('authority-holders.js'),
-    firstAuthorityHoldersNamePage: pagesPath('first-authority-holders-name.js')
+    firstAuthorityHoldersNamePage: pagesPath('first-authority-holders-name.js'),
+    firstAuthorityHoldersBirthPage: pagesPath('first-authority-holders-birth.js'),
+    secondAuthorityHoldersNamePage: pagesPath('second-authority-holders-name.js'),
+    secondAuthorityHoldersBirthPage: pagesPath('second-authority-holders-birth.js')
   }
 };


### PR DESCRIPTION
This PR has the steps for authority holders name. This has been broken up into two steps: first-authority-holders name and second-authority-holders-name. The latter only occurs when 'two' is selected on the authority-holders step.

	* Added steps to route config,
	* Added fields to fields config,
	* Added translations for pages, fields and validation,
	* Added acceptance tests for both the steps,
	* Added page helpers for the tests