### PR TITLE
flho-173 contact address for authority holders

### DIFF
--- a/apps/new-dealer/acceptance/features/contact-address-authority-holder.js
+++ b/apps/new-dealer/acceptance/features/contact-address-authority-holder.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const steps = require('../../');
+
+Feature('Contact address authority holder step');
+
+Before((
+  I,
+  contactAddressAuthorityHolderPage
+) => {
+  I.visitPage(contactAddressAuthorityHolderPage, steps);
+});
+
+Scenario('The correct form elements are present', (
+  I,
+  contactAddressAuthorityHolderPage
+) => {
+  I.seeElements([
+    contactAddressAuthorityHolderPage['contact-address-group'],
+    contactAddressAuthorityHolderPage['different-address'],
+    contactAddressAuthorityHolderPage['same-address']
+  ]);
+});
+
+Scenario('An error is shown if contact-address-authority-holder step is not completed', (
+  I,
+  contactAddressAuthorityHolderPage
+) => {
+  I.submitForm();
+  I.seeErrors(contactAddressAuthorityHolderPage['contact-address-group']);
+});
+
+Scenario('Postcode field is toggled when use a different address is selected', (
+  I,
+  contactAddressAuthorityHolderPage
+) => {
+    I.click(contactAddressAuthorityHolderPage['different-address']);
+    I.seeElement(contactAddressAuthorityHolderPage.postcode);
+});
+
+Scenario('An error is shown if ammunition step is not completed after selecting use a different address', (
+  I,
+  contactAddressAuthorityHolderPage
+) => {
+  I.click(contactAddressAuthorityHolderPage['different-address']);
+  I.submitForm();
+  I.seeErrors(contactAddressAuthorityHolderPage['postcode-group']);
+});
+
+Scenario('First-authority-holder\'s name is in the header', function *(
+  I,
+  contactAddressAuthorityHolderPage
+) {
+  yield I.setSessionData(steps.name, {
+    'contact-holder': 'first',
+    'first-authority-holders-name': 'Sterling Archer',
+  });
+  yield I.refreshPage();
+  I.see(contactAddressAuthorityHolderPage.content['first-contact']);
+});
+
+Scenario('Second-authority-holder\'s name is in the header', function *(
+  I,
+  contactAddressAuthorityHolderPage
+) {
+  yield I.setSessionData(steps.name, {
+    'contact-holder': 'second',
+    'second-authority-holders-name': 'Barry Dylan',
+  });
+  yield I.refreshPage();
+  I.see(contactAddressAuthorityHolderPage.content['second-contact']);
+});
+
+Scenario('I am taken to the contact manual-address step when I click the link', (
+  I,
+  contactAddressAuthorityHolderPage,
+  contactAddressPage
+) => {
+  I.click(contactAddressAuthorityHolderPage['different-address']);
+  I.click(contactAddressAuthorityHolderPage.links['manual-entry']);
+  I.seeInCurrentUrl(contactAddressPage['address-url'])
+});
+
+Scenario('I am taken to the contact-address-lookup step when use-different-address is selected and postcode is provided', (
+  I,
+  contactAddressAuthorityHolderPage,
+  contactAddressPage
+) => {
+  I.click(contactAddressAuthorityHolderPage['different-address']);
+  I.fillField(contactAddressAuthorityHolderPage.postcode, contactAddressAuthorityHolderPage.content.postcode);
+  I.submitForm();
+  I.seeInCurrentUrl(contactAddressPage['address-lookup-url'])
+});
+
+Scenario('I am taken to the summary step when use-same-address is selected', (
+  I,
+  contactAddressAuthorityHolderPage,
+  summaryPage
+) => {
+  I.click(contactAddressAuthorityHolderPage['same-address']);
+  I.submitForm();
+  I.seeInCurrentUrl(summaryPage.url)
+});

--- a/apps/new-dealer/acceptance/features/contact-details.js
+++ b/apps/new-dealer/acceptance/features/contact-details.js
@@ -77,11 +77,28 @@ Scenario('Other contact holder name is in the page header', function *(
 });
 
 
-Scenario('Im taken to the contact-address step', (
+Scenario('When I select someone-else on contact-holder step, I am taken to the contact-postcode step', function *(
   I,
   contactDetailsPage,
   contactAddressPage
-) => {
+) {
+  yield I.setSessionData(steps.name, {
+    'contact-holder': 'other'
+  });
+  yield I.refreshPage();
   contactDetailsPage.fillFormAndSubmit(contactDetailsPage.content['valid-email']);
   I.seeInCurrentUrl(contactAddressPage.url);
+});
+
+Scenario('When I select an authority holder on contact-holder step, I am taken to the contact-address-authority-holder step', function *(
+  I,
+  contactDetailsPage,
+  contactAddressAuthorityHolderPage
+) {
+  yield I.setSessionData(steps.name, {
+    'contact-holder': 'one'
+  });
+  yield I.refreshPage();
+  contactDetailsPage.fillFormAndSubmit(contactDetailsPage.content['valid-email']);
+  I.seeInCurrentUrl(contactAddressAuthorityHolderPage.url);
 });

--- a/apps/new-dealer/acceptance/pages/contact-address-authority-holder.js
+++ b/apps/new-dealer/acceptance/pages/contact-address-authority-holder.js
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = {
+  url: 'contact-address-authority-holder',
+  'contact-address-group':' #use-different-address-group',
+  'different-address': '#use-different-address-true',
+  'same-address': '#use-different-address-false',
+  'postcode-group': '#contact-postcode-group',
+  postcode: '#contact-postcode',
+
+  links: {
+    'manual-entry': '#manual-entry'
+  },
+
+  content: {
+    'first-contact': 'Which address should we use to contact Sterling Archer?',
+    'second-contact': 'Which address should we use to contact Barry Dylan?',
+    postcode: 'CR0 2EU'
+  }
+};

--- a/apps/new-dealer/acceptance/pages/contact-address.js
+++ b/apps/new-dealer/acceptance/pages/contact-address.js
@@ -1,5 +1,7 @@
 'use strict';
 
 module.exports = {
-  url: 'contact-address'
+  url: 'contact-postcode',
+  'address-url': 'contact-address',
+  'address-lookup-url': 'contact-address-lookup'
 };

--- a/apps/new-dealer/acceptance/pages/summary.js
+++ b/apps/new-dealer/acceptance/pages/summary.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  url: 'summary'
+};

--- a/apps/new-dealer/controllers/address-lookup.js
+++ b/apps/new-dealer/controllers/address-lookup.js
@@ -31,6 +31,7 @@ module.exports = class AddressLookup extends BaseController {
     const field = this.options.locals.field;
     const addressLines = req.form.values[`${field}-address-lookup`].split(', ').join('\n');
     req.sessionModel.set(`${field}-address-manual`, addressLines);
+    req.sessionModel.unset('addresses');
 
     super.saveValues(req, res, callback);
   }

--- a/apps/new-dealer/fields/index.js
+++ b/apps/new-dealer/fields/index.js
@@ -572,5 +572,24 @@ module.exports = {
   'contact-phone': {
     mixin: 'input-text',
     validate: 'required'
+  },
+  'use-different-address': {
+    mixin: 'radio-group',
+    validate: 'required',
+    options: [{
+     value: 'false'
+    }, {
+      value: 'true',
+      toggle: 'contact-postcode',
+      child: 'partials/postcode-manual-link'
+    }]
+  },
+  'contact-postcode': {
+    validate: ['required', 'postcode'],
+    formatter: 'uppercase',
+    dependent: {
+      field: 'use-different-address',
+      value: 'true'
+    }
   }
 };

--- a/apps/new-dealer/index.js
+++ b/apps/new-dealer/index.js
@@ -400,13 +400,54 @@ module.exports = {
         'contact-email',
         'contact-phone'
       ],
-      next: '/contact-address',
+      next: '/contact-address-authority-holder',
+      forks: [{
+        target: '/contact-postcode',
+        condition(req) {
+          return req.sessionModel.get('contact-holder') === 'other';
+        }
+      }],
       locals: {
         section: 'contact-details',
         subsection: 'contact-details-confirmation'
       }
     },
+    '/contact-address-authority-holder': {
+      controller: require('./controllers/postcode'),
+      fields: [
+        'use-different-address',
+        'contact-postcode'
+      ],
+      next: '/contact-address',
+      forks: [{
+        target: '/summary',
+        condition: {
+          field: 'use-different-address',
+          value: 'false'
+        }
+      }, {
+        target: '/contact-address-lookup',
+        condition(req) {
+          const addresses = req.sessionModel.get('addresses');
+          return addresses && addresses.length;
+        }
+      }],
+      locals: {
+        section: 'contact-address-authority-holder',
+        field: 'contact'
+      }
+    },
+    '/contact-postcode': {
+      next: '/contact-address-lookup'
+    },
+    '/contact-address-lookup': {
+      next: '/summary'
+    },
     '/contact-address': {
+      next: '/summary'
+    },
+    '/summary': {
+
     }
   }
 };

--- a/apps/new-dealer/translations/src/en/fields.json
+++ b/apps/new-dealer/translations/src/en/fields.json
@@ -471,5 +471,19 @@
   },
   "contact-phone": {
     "label": "Phone number"
+  },
+  "use-different-address": {
+    "legend": "You should only use a home address if it's the business' registered address.",
+    "options": {
+      "false": {
+        "label": "Use the home address already provided"
+      },
+      "true": {
+        "label": "Use a different address"
+      }
+    }
+  },
+  "contact-postcode": {
+    "label": "Postcode"
   }
 }

--- a/apps/new-dealer/translations/src/en/pages.json
+++ b/apps/new-dealer/translations/src/en/pages.json
@@ -136,5 +136,13 @@
   },
   "contact-details-confirmation": {
     "header": "A confirmation email of this application will be sent to this address."
+  },
+  "contact-address-authority-holder": {
+    "header": {
+      "contact-holder": {
+        "first": "Which address should we use to contact {{values.first-authority-holders-name}}?",
+        "second": "Which address should we use to contact {{values.second-authority-holders-name}}?"
+      }
+    }
   }
 }

--- a/apps/new-dealer/translations/src/en/validation.json
+++ b/apps/new-dealer/translations/src/en/validation.json
@@ -219,5 +219,12 @@
   },
   "contact-phone": {
     "required": "Enter contact's phone number"
+  },
+  "use-different-address": {
+    "required": "Select an option"
+  },
+  "contact-postcode": {
+    "required": "Enter a postcode",
+    "postcode": "Enter a valid postcode"
   }
 }

--- a/apps/new-dealer/views/partials/postcode-manual-link.html
+++ b/apps/new-dealer/views/partials/postcode-manual-link.html
@@ -1,0 +1,10 @@
+<div id="{{toggle}}-panel" class="reveal" aria-hidden="false">
+  <div class="panel-indent">
+    {{#input-text}}{{toggle}}{{/input-text}}
+    <p>
+      <span class="link">
+        <a id='manual-entry' href="{{baseUrl}}/{{field}}-address/manual">{{#t}}pages.postcode.manual{{/t}}</a>
+      </span>
+    </p>
+  </div>
+</div>

--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -31,6 +31,8 @@ module.exports = {
     storageAnotherAddressPage: pagesPath('storage-add-another-address.js'),
     contactPage: pagesPath('contact.js'),
     contactDetailsPage: pagesPath('contact-details.js'),
-    contactAddressPage: pagesPath('contact-address.js')
+    contactAddressPage: pagesPath('contact-address.js'),
+    contactAddressAuthorityHolderPage: pagesPath('contact-address-authority-holder.js'),
+    summaryPage: pagesPath('summary.js')
   }
 };


### PR DESCRIPTION
* Aded step to routes config,
* Added fields to field config,
* Added translations for pages, fields and validation,
* Added partial for the toggled field on step,
* Added acceptance tests,
* Added page helpers for the tests.
* fixed issue with addresses still being set in the sessionModel after it was used for previous postcode lookup