### PR TITLE
flho-152 contact-address

### DIFF
--- a/apps/new-dealer/acceptance/features/contact-address-authority-holder.js
+++ b/apps/new-dealer/acceptance/features/contact-address-authority-holder.js
@@ -38,7 +38,7 @@ Scenario('Postcode field is toggled when use a different address is selected', (
     I.seeElement(contactAddressAuthorityHolderPage.fields.postcode);
 });
 
-Scenario('An error is shown if ammunition step is not completed after selecting use a different address', (
+Scenario('An error is shown if the step is not completed after selecting use a different address', (
   I,
   contactAddressAuthorityHolderPage
 ) => {

--- a/apps/new-dealer/acceptance/features/contact-address.js
+++ b/apps/new-dealer/acceptance/features/contact-address.js
@@ -1,0 +1,142 @@
+'use strict';
+
+const steps = require('../../');
+
+Feature('Contact address');
+
+Before((
+  I,
+  contactAddressPage
+) => {
+  I.visitPage(contactAddressPage, steps);
+});
+
+Scenario('The correct form elements are present', (
+  I,
+  contactAddressPage
+) => {
+  I.seeElement(contactAddressPage.fields.postcode);
+});
+
+Scenario('An error is shown if contact-postcode step is not completed', (
+  I,
+  contactAddressPage
+) => {
+  I.submitForm();
+  I.seeErrors(contactAddressPage.fields.postcode);
+});
+
+Scenario('Contact\'s name is in the header of postcode step', function *(
+  I,
+  contactAddressPage
+) {
+  yield I.setSessionData(steps.name, {
+    'someone-else-name': 'Sterling Archer'
+  });
+  yield I.refreshPage();
+  I.see(contactAddressPage.content.header);
+});
+
+Scenario('I am taken to the contact manual-address step when I click the link', (
+  I,
+  contactAddressPage
+) => {
+  I.click(contactAddressPage.links['manual-entry']);
+  I.seeInCurrentUrl(contactAddressPage['address-url'])
+});
+
+Scenario('I am taken to the contact-address-lookup step when postcode is entered', (
+  I,
+  contactAddressPage
+) => {
+  contactAddressPage.fillFormAndSubmit(contactAddressPage.fields.postcode)
+  I.seeInCurrentUrl(contactAddressPage['address-lookup-url'])
+});
+
+
+Scenario('The correct form elements are present for contact manual address step', (
+  I,
+  contactAddressPage
+) => {
+  I.click(contactAddressPage.links['manual-entry']);
+  I.seeElements(contactAddressPage.fields['address-manual']);
+});
+
+Scenario('Contact\'s name is in the page header of the manual-address step', function *(
+  I,
+  contactAddressPage
+) {
+  I.click(contactAddressPage.links['manual-entry']);
+  yield I.setSessionData(steps.name, {
+    'someone-else-name': 'Sterling Archer'
+  });
+  yield I.refreshPage();
+  I.see(contactAddressPage.content.header);
+});
+
+Scenario('An error is shown if contact manual address is not completed', (
+  I,
+  contactAddressPage
+) => {
+  I.click(contactAddressPage.links['manual-entry']);
+  I.submitForm();
+  I.seeErrors(contactAddressPage.fields['address-manual']);
+});
+
+Scenario('An error is shown if contact-address-lookup is not completed', (
+  I,
+  contactAddressPage
+) => {
+  contactAddressPage.fillFormAndSubmit(contactAddressPage.fields.postcode);
+  I.submitForm();
+  I.seeErrors(contactAddressPage.fields['address-lookup']);
+});
+
+Scenario('Contact\'s name is in the page header of the address-lookup step', function *(
+  I,
+  contactAddressPage
+) {
+  contactAddressPage.fillFormAndSubmit(contactAddressPage.fields.postcode);
+  yield I.setSessionData(steps.name, {
+    'someone-else-name': 'Sterling Archer'
+  });
+  yield I.refreshPage();
+  I.see(contactAddressPage.content.header);
+});
+
+Scenario('I am taken to the contact manual address step if I cant find my address', (
+  I,
+  contactAddressPage
+) => {
+  contactAddressPage.fillFormAndSubmit(contactAddressPage.fields.postcode);
+  I.click(contactAddressPage.links['cant-find-address']);
+  I.seeInCurrentUrl(contactAddressPage['address-url']);
+});
+
+Scenario('When I click cant find my address link, I will see the postcode I entered in the contact manual address step', (
+  I,
+  contactAddressPage
+) => {
+  contactAddressPage.fillFormAndSubmit(contactAddressPage.fields.postcode);
+  I.click(contactAddressPage.links['cant-find-address']);
+  I.see(contactAddressPage.content.postcode);
+});
+
+Scenario('I am taken to the summary step from the manual-address step', (
+  I,
+  contactAddressPage,
+  summaryPage
+) => {
+  I.click(contactAddressPage.links['manual-entry']);
+  contactAddressPage.fillFormAndSubmit(contactAddressPage.fields['address-manual']);
+  I.seeInCurrentUrl(summaryPage.url);
+});
+
+Scenario('When an address is selected I am taken to the summary step', (
+  I,
+  contactAddressPage,
+  summaryPage
+) => {
+  contactAddressPage.selectAddressAndSubmit();
+  I.seeInCurrentUrl(summaryPage.url);
+});

--- a/apps/new-dealer/acceptance/pages/contact-address.js
+++ b/apps/new-dealer/acceptance/pages/contact-address.js
@@ -1,7 +1,42 @@
 'use strict';
 
+let I;
+
 module.exports = {
+
+  _init() {
+    I = require('so-acceptance/steps')();
+  },
+
   url: 'contact-postcode',
   'address-url': 'contact-address',
-  'address-lookup-url': 'contact-address-lookup'
+  'address-lookup-url': 'contact-address-lookup',
+
+  fields: {
+    postcode: '#contact-postcode',
+    'address-manual': '#contact-address-manual',
+    'address-lookup': '#contact-address-lookup'
+  },
+
+  links: {
+    'manual-entry': '#manual-entry',
+    'cant-find-address': '#cant-find'
+  },
+
+  content: {
+    header: 'What is Sterling Archer\'s address?',
+    postcode: 'CR0 2EU',
+    address: '49 Sydenham Road, Croydon, CR0 2EU'
+  },
+
+  fillFormAndSubmit(field) {
+    I.fillField(field, this.content.postcode);
+    I.submitForm();
+  },
+
+  selectAddressAndSubmit() {
+    this.fillFormAndSubmit(this.fields.postcode);
+    I.selectOption(this.fields['address-lookup'], this.content.address);
+    I.submitForm();
+  }
 };

--- a/apps/new-dealer/fields/index.js
+++ b/apps/new-dealer/fields/index.js
@@ -604,5 +604,23 @@ module.exports = {
       attribute: 'height',
       value: 6
     }]
+  },
+  'contact-postcode': {
+    mixin: 'input-text-code',
+    validate: ['required', 'postcode'],
+    formatter: 'uppercase'
+  },
+  'contact-address-lookup': {
+    className: 'address'
+  },
+  'contact-address-manual': {
+    mixin: 'textarea',
+    validate: 'required',
+    'ignore-defaults': true,
+    formatter: ['trim', 'hyphens'],
+    attributes: [{
+      attribute: 'height',
+      value: 6
+    }]
   }
 };

--- a/apps/new-dealer/index.js
+++ b/apps/new-dealer/index.js
@@ -464,13 +464,49 @@ module.exports = {
       }
     },
     '/contact-postcode': {
-      next: '/contact-address-lookup'
+      template: 'postcode.html',
+      controller: require('./controllers/postcode'),
+      fields: [
+        'contact-postcode'
+      ],
+      next: '/contact-address',
+      forks: [{
+        target: '/contact-address-lookup',
+        condition(req) {
+          const addresses = req.sessionModel.get('addresses');
+          return addresses && addresses.length;
+        }
+      }],
+      locals: {
+        section: 'contact-address',
+        field: 'contact'
+      }
     },
     '/contact-address-lookup': {
-      next: '/summary'
+      template: 'address-lookup.html',
+      controller: require('./controllers/address-lookup'),
+      fields: [
+        'contact-address-lookup'
+      ],
+      next: '/summary',
+      locals: {
+        section: 'contact-address',
+        field: 'contact'
+      }
     },
     '/contact-address': {
-      next: '/summary'
+      template: 'address.html',
+      controller: require('./controllers/address'),
+      fields: [
+        'contact-address-manual'
+      ],
+      next: '/summary',
+      prereqs: ['/contact-postcode', '/contact-details'],
+      backLink: 'contact-postcode',
+      locals: {
+        section: 'contact-address',
+        field: 'contact'
+      }
     },
     '/summary': {
     }

--- a/apps/new-dealer/translations/src/en/fields.json
+++ b/apps/new-dealer/translations/src/en/fields.json
@@ -491,5 +491,14 @@
   },
   "authority-holder-contact-address-manual": {
     "label": "Address"
+  },
+  "contact-postcode": {
+    "label": "Postcode"
+  },
+  "contact-address-manual": {
+    "label": "Address"
+  },
+  "contact-address-lookup": {
+    "label": "Select your address"
   }
 }

--- a/apps/new-dealer/translations/src/en/pages.json
+++ b/apps/new-dealer/translations/src/en/pages.json
@@ -144,5 +144,8 @@
         "second": "Which address should we use to contact {{values.second-authority-holders-name}}?"
       }
     }
+  },
+  "contact-address": {
+    "header": "What is {{values.someone-else-name}}'s address?"
   }
 }

--- a/apps/new-dealer/translations/src/en/validation.json
+++ b/apps/new-dealer/translations/src/en/validation.json
@@ -232,5 +232,15 @@
   },
   "authority-holder-contact-address-manual": {
     "required": "Enter an address"
+  },
+  "contact-postcode": {
+    "required": "Enter a postcode",
+    "postcode": "Enter a valid postcode"
+  },
+  "contact-address-manual": {
+    "required": "Enter an address"
+  },
+  "contact-address-lookup": {
+    "required": "Select an address"
   }
 }


### PR DESCRIPTION
Added the contact address step non authority holders. Consists of the postcode, manual-address and address-lookup steps.

* Added the steps to the route config,
* Added the fields to the fields config,
* Added the translations for the pages, fields and validation,
* Added the acceptance tests for the steps.