### PR TITLE
bugfix/flho-237

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -4,6 +4,7 @@ var toolkit = require('hof').toolkit;
 var helpers = toolkit.helpers;
 var progressiveReveal = toolkit.progressiveReveal;
 var formFocus = toolkit.formFocus;
+toolkit.detailsSummary();
 
 helpers.documentReady(progressiveReveal);
 helpers.documentReady(formFocus);


### PR DESCRIPTION
Call the detailsSummary function in the toolkit. Fixes and issue with Microsoft browsers with details summary section not being clickable and not toggling the summary