### PR TITLE
flho-178 authority-number-renew-vary step

### DIFF
--- a/apps/new-dealer/acceptance/features/authority-number-renew-vary.js
+++ b/apps/new-dealer/acceptance/features/authority-number-renew-vary.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const steps = require('../../');
+
+Feature('Authority number renew vary step');
+
+Before((
+  I,
+  authorityNumberRenewPage
+) => {
+  I.visitPage(authorityNumberRenewPage, steps);
+});
+
+Scenario('The correct form elements are present', (
+  I,
+  authorityNumberRenewPage
+) => {
+  I.seeElements([
+    authorityNumberRenewPage['authority-number'],
+    authorityNumberRenewPage['reference-number']
+  ]);
+});
+
+Scenario('An error is shown if authority-number-renew-vary step is not completed', (
+  I,
+  authorityNumberRenewPage
+) => {
+  I.submitForm();
+  I.seeErrors([
+    authorityNumberRenewPage['authority-number-group'],
+    authorityNumberRenewPage['reference-number-group']
+  ]);
+});
+
+Scenario('I am taken to the expiration-renew-vary step', (
+  I,
+  authorityNumberRenewPage,
+  expirationRenewVaryPage
+) => {
+  I.fillField(authorityNumberRenewPage['authority-number'], authorityNumberRenewPage.content.number);
+  I.fillField(authorityNumberRenewPage['reference-number'], authorityNumberRenewPage.content.number);
+  I.submitForm();
+  I.seeInCurrentUrl(expirationRenewVaryPage.url);
+});

--- a/apps/new-dealer/acceptance/pages/authority-holder-renew-vary.js
+++ b/apps/new-dealer/acceptance/pages/authority-holder-renew-vary.js
@@ -1,5 +1,13 @@
 'use strict';
 
 module.exports = {
-  url: 'authority-number-renew-vary'
+  url: 'authority-number-renew-vary',
+  'authority-number-group': '#authority-number-group',
+  'authority-number': '#authority-number',
+  'reference-number-group': '#reference-number-group',
+  'reference-number': '#reference-number',
+
+  content: {
+    number: '0123456789'
+  }
 };

--- a/apps/new-dealer/acceptance/pages/expiration-renew-vary.js
+++ b/apps/new-dealer/acceptance/pages/expiration-renew-vary.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  url: 'expiration-renew-vary'
+};

--- a/apps/new-dealer/fields/index.js
+++ b/apps/new-dealer/fields/index.js
@@ -17,6 +17,14 @@ module.exports = {
       'renew'
     ]
   },
+  'authority-number': {
+    mixin: 'input-text',
+    validate: 'required'
+  },
+  'reference-number': {
+    mixin: 'input-text',
+    validate: 'required'
+  },
   company: {
     mixin: 'radio-group',
     validate: 'required',

--- a/apps/new-dealer/index.js
+++ b/apps/new-dealer/index.js
@@ -32,7 +32,14 @@ module.exports = {
       }
     },
     '/authority-number-renew-vary': {
-      next: '/expiration-renew-vary'
+      fields: [
+        'authority-number',
+        'reference-number'
+      ],
+      next: '/expiration-renew-vary',
+      locals: {
+        section: 'authority-number-renew-vary'
+      }
     },
     '/expiration-renew-vary': {
       next: '/company-name'

--- a/apps/new-dealer/translations/src/en/fields.json
+++ b/apps/new-dealer/translations/src/en/fields.json
@@ -11,6 +11,13 @@
       }
     }
   },
+  "authority-number": {
+    "hint": "For example, 16/B/D/001",
+    "label": "Current authority number"
+  },
+  "reference-number": {
+    "label": "Reference number"
+  },
   "company": {
     "options": {
       "true": {

--- a/apps/new-dealer/translations/src/en/pages.json
+++ b/apps/new-dealer/translations/src/en/pages.json
@@ -2,6 +2,11 @@
   "activity": {
     "header": "What do you want to do with the S5 authority?"
   },
+  "authority-number-renew-vary": {
+    "header": "What's the current authority and reference numbers?",
+    "summary-header": "Help with authority and reference numbers",
+    "details": "The current authority number will be replaced with a new number once the renewal or variation is approved. <br> The reference number is a unique number for the company or individual that never changes."
+  },
   "company-name": {
     "header": "Are you applying on behalf of a company or as a sole trader?"
   },

--- a/apps/new-dealer/translations/src/en/validation.json
+++ b/apps/new-dealer/translations/src/en/validation.json
@@ -2,6 +2,12 @@
   "activity": {
     "required": "Select an option"
   },
+  "authority-number": {
+    "required": "Enter reference number of authority you are renewing/varying"
+  },
+  "reference-number": {
+    "required": "Enter your customer reference number"
+  },
   "company": {
     "required": "Select whether you're applying on behalf of a company or a sole trader"
   },

--- a/apps/new-dealer/views/authority-number-renew-vary.html
+++ b/apps/new-dealer/views/authority-number-renew-vary.html
@@ -5,11 +5,11 @@
     {{/fields}}
     <details>
       <summary class="summary-details" role="button">
-        <span class="summary">{{#t}}fields.activity.header{{/t}}</span>
+        <span class="summary">{{#t}}pages.authority-number-renew-vary.summary-header{{/t}}</span>
       </summary>
       <div class="panel-indent">
-        <div id="activity-details-summary">
-          {{#t}}fields.activity.summary-details{{/t}}
+        <div id="authority-number-details-summary">
+          {{#t}}pages.authority-number-renew-vary.details{{/t}}
         </div>
       </div>
     </details>

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -69,6 +69,6 @@ span.postcode {
   margin-right: 0.5em;
 }
 
-summary.activity-details {
+summary.summary-details {
   margin-bottom: 20px;
 }

--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -11,6 +11,7 @@ module.exports = {
   include: {
     activityPage: pagesPath('activity.js'),
     authorityNumberRenewPage: pagesPath('authority-holder-renew-vary.js'),
+    expirationRenewVaryPage: pagesPath('expiration-renew-vary.js'),
     companyNamePage: pagesPath('company-name.js'),
     handlePage: pagesPath('handle.js'),
     obtainPage: pagesPath('obtain.js'),


### PR DESCRIPTION
Added the authority-number-renew-vary step:
- Added the step to the routes config,
- Added the fields to the fields config,
- Added the custom html template,
- Added the translations for the page, fields and validation,
- Added the acceptance tests for the step and the page object,
- Changed the css class on the activity template and app.scss so it can be re-used for all summary-details sections
