### PR TITLE
Added clearSession: false to the summary step

### DIFF
--- a/apps/new-dealer/index.js
+++ b/apps/new-dealer/index.js
@@ -531,6 +531,7 @@ module.exports = {
       }
     },
     '/summary': {
+      clearSession: false
     }
   }
 };


### PR DESCRIPTION
The testers are trying to test the end of the form but as soon as they click continue and end up on the smmary page, all the session data is cleared and they have to start the form again instead of being able to click back. 

So added `clearSession: false` to the summary step in the routes config to aid them.