### PR TITLE
flho-163 storage-add-another-address

### DIFF
--- a/apps/new-dealer/acceptance/features/storage-address.js
+++ b/apps/new-dealer/acceptance/features/storage-address.js
@@ -32,7 +32,7 @@ Scenario('I am taken to the storage-lookup step from postcode', (
   I,
   storageAddressPage
 ) => {
-  storageAddressPage.fillFormAndSubmit(storageAddressPage.fields.postcode);
+  storageAddressPage.fillFormAndSubmit(storageAddressPage.fields.postcode, storageAddressPage.content.postcode);
   I.seeInCurrentUrl(storageAddressPage['address-lookup-url']);
 });
 
@@ -67,7 +67,7 @@ Scenario('An error is shown if storage-address-lookup is not completed', (
   I,
   storageAddressPage
 ) => {
-  storageAddressPage.fillFormAndSubmit(storageAddressPage.fields.postcode);
+  storageAddressPage.fillFormAndSubmit(storageAddressPage.fields.postcode, storageAddressPage.content.postcode);
   I.submitForm();
   I.seeErrors(storageAddressPage.fields['address-lookup']);
 });
@@ -76,7 +76,7 @@ Scenario('I am taken to the storage-manual-address step if I cant find my addres
   I,
   storageAddressPage
 ) => {
-  storageAddressPage.fillFormAndSubmit(storageAddressPage.fields.postcode);
+  storageAddressPage.fillFormAndSubmit(storageAddressPage.fields.postcode, storageAddressPage.content.postcode);
   I.click(storageAddressPage.links['cant-find-address']);
   I.seeInCurrentUrl(storageAddressPage['address-url']);
 });
@@ -85,7 +85,7 @@ Scenario('When I click cant find my address link, I will see the postcode I ente
   I,
   storageAddressPage
 ) => {
-  storageAddressPage.fillFormAndSubmit(storageAddressPage.fields.postcode);
+  storageAddressPage.fillFormAndSubmit(storageAddressPage.fields.postcode, storageAddressPage.content.postcode);
   I.click(storageAddressPage.links['cant-find-address']);
   I.see(storageAddressPage.content.postcode);
 });
@@ -150,19 +150,138 @@ Scenario('When I select ammunition on the handle step then all headers use ammun
 
 Scenario('I am taken to the storage-add-another-address step from the address-lookup step', (
   I,
-  storageAddressPage,
-  storageAnotherAddressPage
+  storageAddressPage
 ) => {
   storageAddressPage.selectAddressAndSubmit();
-  I.seeInCurrentUrl(storageAnotherAddressPage.url);
+  I.seeInCurrentUrl(storageAddressPage['another-address-url']);
 });
 
 Scenario('I am taken to the storage-add-another-address step from the manual-address step', (
   I,
-  storageAddressPage,
-  storageAnotherAddressPage
+  storageAddressPage
 ) => {
   I.click(storageAddressPage.links['manual-entry']);
   storageAddressPage.fillFormAndSubmit(storageAddressPage.fields['address-manual']);
-  I.seeInCurrentUrl(storageAnotherAddressPage.url);
+  I.seeInCurrentUrl(storageAddressPage['another-address-url']);
+});
+
+Scenario('The correct form elements are present on storage-add-another-address step', (
+  I,
+  storageAddressPage
+) => {
+  storageAddressPage.selectAddressAndSubmit();
+  I.seeElements([
+    storageAddressPage.fields.add,
+    storageAddressPage.fields.yes,
+    storageAddressPage.fields.no
+  ]);
+});
+
+Scenario('An error is shown if storage-add-another-address step is not completed', (
+  I,
+  storageAddressPage
+) => {
+  storageAddressPage.selectAddressAndSubmit();
+  I.submitForm();
+  I.seeErrors(storageAddressPage.fields.add);
+});
+
+Scenario('I see the storage-address that was added previously', (
+  I,
+  storageAddressPage
+) => {
+  storageAddressPage.selectAddressAndSubmit();
+  I.see(storageAddressPage.content.address);
+});
+
+Scenario('When I select yes on the add-another-address page, I am taken to the storage-postcode step', (
+  I,
+  storageAddressPage
+) => {
+  storageAddressPage.selectAddressAndSubmit();
+  I.click(storageAddressPage.fields.yes);
+  I.submitForm();
+  I.seeInCurrentUrl(storageAddressPage.url);
+});
+
+Scenario('When I add another address, I can see both addresses on the add-another-address step', (
+  I,
+  storageAddressPage
+) => {
+  storageAddressPage.selectAddressAndSubmit();
+  I.click(storageAddressPage.fields.yes);
+  I.submitForm();
+  I.click(storageAddressPage.links['manual-entry']);
+  storageAddressPage.fillFormAndSubmit(storageAddressPage.fields['address-manual'], storageAddressPage.content['another-address']);
+  I.seeEach([
+    storageAddressPage.content.address,
+    storageAddressPage.content['another-address']
+  ])
+});
+
+Scenario('When I click Change, I am taken back to the storage-postcode page', (
+  I,
+  storageAddressPage
+) => {
+  storageAddressPage.selectAddressAndSubmit();
+  I.click(storageAddressPage.links.change);
+  I.seeInCurrentUrl(`${storageAddressPage.url}/edit/0`);
+});
+
+Scenario('When I change the address, I can see the new address on the storage-add-another-address page', (
+  I,
+  storageAddressPage
+) => {
+  storageAddressPage.selectAddressAndSubmit();
+  I.see(storageAddressPage.content.address);
+  I.click(storageAddressPage.links.change);
+  I.click(storageAddressPage.links['manual-entry']);
+  storageAddressPage.fillFormAndSubmit(storageAddressPage.fields['address-manual'], storageAddressPage.content['another-address']);
+  I.dontSee(storageAddressPage.content.address);
+  I.see(storageAddressPage.content['another-address']);
+});
+
+Scenario('When I select weapons on the handle step, when I select No I am taken to the weapons page', function *(
+  I,
+  storageAddressPage,
+  weaponsPage
+) {
+  yield I.setSessionData(steps.name, {
+    'weapons-ammunition': 'weapons'
+  });
+  yield I.refreshPage();
+  storageAddressPage.selectAddressAndSubmit();
+  I.click(storageAddressPage.fields.no);
+  I.submitForm();
+  I.seeInCurrentUrl(weaponsPage.url);
+});
+
+Scenario('When I select ammunition on the handle step, when I select No I am taken to the ammunition page', function *(
+  I,
+  storageAddressPage,
+  ammunitionsPage
+) {
+  yield I.setSessionData(steps.name, {
+    'weapons-ammunition': 'ammunition'
+  });
+  yield I.refreshPage();
+  storageAddressPage.selectAddressAndSubmit();
+  I.click(storageAddressPage.fields.no);
+  I.submitForm();
+  I.seeInCurrentUrl(ammunitionsPage.url);
+});
+
+Scenario('When I select weapons and ammunition on the handle step, when I select No I am taken to the ammunition page', function *(
+  I,
+  storageAddressPage,
+  weaponsPage
+) {
+  yield I.setSessionData(steps.name, {
+    'weapons-ammunition': 'weapons,ammunition'
+  });
+  yield I.refreshPage();
+  storageAddressPage.selectAddressAndSubmit();
+  I.click(storageAddressPage.fields.no);
+  I.submitForm();
+  I.seeInCurrentUrl(weaponsPage.url);
 });

--- a/apps/new-dealer/acceptance/features/storage-address.js
+++ b/apps/new-dealer/acceptance/features/storage-address.js
@@ -161,7 +161,7 @@ Scenario('I am taken to the storage-add-another-address step from the manual-add
   storageAddressPage
 ) => {
   I.click(storageAddressPage.links['manual-entry']);
-  storageAddressPage.fillFormAndSubmit(storageAddressPage.fields['address-manual']);
+  storageAddressPage.fillFormAndSubmit(storageAddressPage.fields['address-manual'], storageAddressPage.content.address);
   I.seeInCurrentUrl(storageAddressPage['another-address-url']);
 });
 

--- a/apps/new-dealer/acceptance/pages/storage-add-another-address.js
+++ b/apps/new-dealer/acceptance/pages/storage-add-another-address.js
@@ -1,5 +1,0 @@
-'use strict';
-
-module.exports = {
-  url: 'storage-add-another-address'
-};

--- a/apps/new-dealer/acceptance/pages/storage-address.js
+++ b/apps/new-dealer/acceptance/pages/storage-address.js
@@ -14,21 +14,27 @@ module.exports = {
   url: 'storage-postcode',
   'address-url': 'storage-address',
   'address-lookup-url': 'storage-address-lookup',
+  'another-address-url': 'storage-add-another-address',
 
   fields: {
     postcode: '#storage-postcode',
     'address-manual': '#storage-address-manual',
-    'address-lookup': '#storage-address-lookup'
+    'address-lookup': '#storage-address-lookup',
+    add: '#storage-add-another-address-group',
+    yes: '#storage-add-another-address-yes',
+    no: '#storage-add-another-address-no',
   },
 
   links: {
     'manual-entry': '#manual-entry',
-    'cant-find-address': '#cant-find'
+    'cant-find-address': '#cant-find',
+    change: 'Change'
   },
 
   content: {
     postcode: 'CR0 2EU',
-    address: '49 Sydenham Road, Croydon, CR0 2EU'
+    address: '49 Sydenham Road, Croydon, CR0 2EU',
+    'another-address': '2 Marsham Street, London'
   },
 
   getHeaderTranslations(handleType, storageType){
@@ -48,13 +54,13 @@ module.exports = {
     I.see(translation);
   },
 
-  fillFormAndSubmit(field) {
-    I.fillField(field, this.content.postcode);
+  fillFormAndSubmit(field, content) {
+    I.fillField(field, content);
     I.submitForm();
   },
 
   selectAddressAndSubmit() {
-    this.fillFormAndSubmit(this.fields.postcode);
+    this.fillFormAndSubmit(this.fields.postcode, this.content.postcode);
     I.selectOption(this.fields['address-lookup'], this.content.address);
     I.submitForm();
   }

--- a/apps/new-dealer/acceptance/pages/storage-address.js
+++ b/apps/new-dealer/acceptance/pages/storage-address.js
@@ -48,7 +48,7 @@ module.exports = {
   correctTranslationsShown(handleType, storageType) {
     const translation = this.getHeaderTranslations(handleType, storageType);
     I.see(translation);
-    this.fillFormAndSubmit(this.fields.postcode);
+    this.fillFormAndSubmit(this.fields.postcode, this.content.postcode);
     I.see(translation);
     I.click(this.links['cant-find-address']);
     I.see(translation);

--- a/apps/new-dealer/controllers/address-lookup.js
+++ b/apps/new-dealer/controllers/address-lookup.js
@@ -22,7 +22,6 @@ module.exports = class AddressLookup extends BaseController {
       };
     });
 
-    // const field = this.options.locals.field;
     const count = `${formattedlist.length} addresses`;
     this.options.fields[`${field}-address-lookup`].options = [{value: count, label: count}].concat(formattedlist);
     super.getValues(req, res, callback);

--- a/apps/new-dealer/controllers/address-lookup.js
+++ b/apps/new-dealer/controllers/address-lookup.js
@@ -12,7 +12,8 @@ module.exports = class AddressLookup extends BaseController {
   }
 
   getValues(req, res, callback) {
-    const addresses = req.sessionModel.get('addresses');
+    const field = this.options.locals.field;
+    const addresses = req.sessionModel.get(`${field}-addresses`);
     const formattedlist = _.map(_.map(addresses, 'formatted_address'), address => {
       address = address.split('\n').join(', ');
       return {
@@ -21,7 +22,7 @@ module.exports = class AddressLookup extends BaseController {
       };
     });
 
-    const field = this.options.locals.field;
+    // const field = this.options.locals.field;
     const count = `${formattedlist.length} addresses`;
     this.options.fields[`${field}-address-lookup`].options = [{value: count, label: count}].concat(formattedlist);
     super.getValues(req, res, callback);

--- a/apps/new-dealer/controllers/postcode.js
+++ b/apps/new-dealer/controllers/postcode.js
@@ -8,6 +8,7 @@ const _ = require('lodash');
 
 module.exports = class PostcodeController extends BaseController {
   process(req, res, callback) {
+    const postcodesModel = new PostcodesModel();
     const field = this.options.locals.field;
     const postcode = req.form.values[`${field}-postcode`];
     const previousPostcode = req.sessionModel.get(`${field}-postcode`);
@@ -22,7 +23,6 @@ module.exports = class PostcodeController extends BaseController {
       return callback();
     }
 
-    const postcodesModel = new PostcodesModel();
     postcodesModel.fetch(postcode)
       .then(data => {
         if (data.length) {

--- a/apps/new-dealer/controllers/postcode.js
+++ b/apps/new-dealer/controllers/postcode.js
@@ -18,7 +18,7 @@ module.exports = class PostcodeController extends BaseController {
 
     if (_.startsWith(postcode, 'BT')) {
       req.sessionModel.unset('postcodeApiMeta');
-      req.sessionModel.unset('addresses');
+      req.sessionModel.unset(`${field}-addresses`);
       return callback();
     }
 
@@ -26,9 +26,9 @@ module.exports = class PostcodeController extends BaseController {
     postcodesModel.fetch(postcode)
       .then(data => {
         if (data.length) {
-          req.sessionModel.set('addresses', data);
+          req.sessionModel.set(`${field}-addresses`, data);
         } else {
-          req.sessionModel.unset('addresses');
+          req.sessionModel.unset(`${field}-addresses`);
           req.sessionModel.set('postcodeApiMeta', {
             messageKey: 'not-found'
           });

--- a/apps/new-dealer/controllers/storage-add-another-address.js
+++ b/apps/new-dealer/controllers/storage-add-another-address.js
@@ -1,0 +1,29 @@
+'use strict';
+const BaseController = require('hof').controllers.base;
+const _ = require('lodash');
+
+module.exports = class AddNewAddress extends BaseController {
+  locals(req, res, callback) {
+    const locals = super.locals(req, res, callback);
+    const addresses = req.sessionModel.get('storageAddresses');
+    const hasStorageAddresses = req.sessionModel.get('storageAddresses') ? true : false;
+    const storageAddresses = [];
+    _.forEach(addresses, (value, key) => {
+      const address = {
+        id: key,
+        address: value.address
+      };
+      storageAddresses.push(address);
+    });
+    return Object.assign({}, locals, {
+      storageAddresses,
+      hasStorageAddresses
+    });
+  }
+
+  getBackLink(req, res, callback) {
+    const addresses = req.sessionModel.get('storageAddresses');
+    const id = _.last(Object.keys(addresses));
+    return `${super.getBackLink(req, res, callback)}/edit/${id}`;
+  }
+};

--- a/apps/new-dealer/controllers/storage-address-lookup.js
+++ b/apps/new-dealer/controllers/storage-address-lookup.js
@@ -1,0 +1,94 @@
+'use strict';
+const BaseController = require('hof').controllers.base;
+const ErrorController = require('hof').controllers.error;
+const _ = require('lodash');
+
+module.exports = class StorageAddressLookup extends BaseController {
+  locals(req, res) {
+    const locals = super.locals(req, res);
+    let postcode;
+    let id;
+    const addresses = req.sessionModel.get('storageAddresses');
+    const hasStorageAddresses = req.sessionModel.get('storageAddresses') ? true : false;
+    const storageAddresses = [];
+    _.forEach(addresses, (value, key) => {
+      const address = {
+        id: key,
+        address: value.address
+      };
+      storageAddresses.push(address);
+    });
+    if (req.params.action === 'edit') {
+      id = req.params.id;
+      postcode = addresses[id].postcode || req.sessionModel.get('storage-postcode');
+    } else {
+      postcode = req.sessionModel.get('storage-postcode');
+    }
+    return Object.assign({}, locals, {storageAddresses, hasStorageAddresses, postcode, id});
+  }
+
+  getBackLink(req, res, callback) {
+    const id = req.params.action === 'edit' ? req.params.id : '';
+    return `${super.getBackLink(req, res, callback)}/${id}`;
+  }
+
+  getValues(req, res, callback) {
+    if (req.params.action === 'edit') {
+      const steps = req.sessionModel.get('steps');
+      _.remove(steps, step => {
+        return step === '/storage-add-another-address';
+      });
+      req.sessionModel.set('steps', steps);
+      req.sessionModel.unset('storage-add-another-address');
+    }
+    const field = this.options.locals.field;
+    const addresses = req.sessionModel.get('storage-addresses');
+    const formattedlist = _.map(_.map(addresses, 'formatted_address'), address => {
+      address = address.split('\n').join(', ');
+      return {
+        value: address,
+        label: address
+      };
+    });
+
+    const count = `${formattedlist.length} addresses`;
+    this.options.fields[`${field}-address-lookup`].options = [{value: count, label: count}].concat(formattedlist);
+    super.getValues(req, res, callback);
+  }
+
+  saveValues(req, res, callback) {
+    let storageAddresses = req.sessionModel.get('storageAddresses') || {};
+    const address = req.form.values['storage-address-lookup'];
+    const postcode = req.sessionModel.get('storage-postcode');
+
+    let id = req.params.id;
+
+    if (id === undefined) {
+      const currentIndex = req.sessionModel.get('currentIndex') || 0;
+      id = parseInt(currentIndex, 10);
+      req.sessionModel.set('currentIndex', id + 1);
+    }
+    storageAddresses[id] = {
+      address,
+      postcode
+    };
+    req.sessionModel.set({storageAddresses});
+    req.sessionModel.unset('storage-postcode');
+    super.saveValues(req, res, callback);
+  }
+
+  post(req, res, cb) {
+    this.getValues(req, res, () => {});
+    super.post(req, res, cb);
+  }
+
+  validateField(key, req) {
+    if (req.form.values[key] === this.options.fields['storage-address-lookup'].options[0].value) {
+      return new ErrorController('storage-address-lookup', {
+        key: 'storage-address-lookup',
+        type: 'required',
+        redirect: undefined
+      });
+    }
+  }
+};

--- a/apps/new-dealer/controllers/storage-address-lookup.js
+++ b/apps/new-dealer/controllers/storage-address-lookup.js
@@ -6,11 +6,11 @@ const _ = require('lodash');
 module.exports = class StorageAddressLookup extends BaseController {
   locals(req, res) {
     const locals = super.locals(req, res);
-    let postcode;
-    let id;
     const addresses = req.sessionModel.get('storageAddresses');
     const hasStorageAddresses = req.sessionModel.get('storageAddresses') ? true : false;
     const storageAddresses = [];
+    let postcode;
+    let id;
     _.forEach(addresses, (value, key) => {
       const address = {
         id: key,
@@ -57,10 +57,9 @@ module.exports = class StorageAddressLookup extends BaseController {
   }
 
   saveValues(req, res, callback) {
-    let storageAddresses = req.sessionModel.get('storageAddresses') || {};
     const address = req.form.values['storage-address-lookup'];
     const postcode = req.sessionModel.get('storage-postcode');
-
+    let storageAddresses = req.sessionModel.get('storageAddresses') || {};
     let id = req.params.id;
 
     if (id === undefined) {

--- a/apps/new-dealer/controllers/storage-address.js
+++ b/apps/new-dealer/controllers/storage-address.js
@@ -40,7 +40,7 @@ module.exports = class AddressController extends BaseController {
     super.getValues(req, res, (err, values) => {
       if (err) {
         // eslint-disable-next-line no-console
-        console.error(err);
+        callback(err);
         return callback(null, values);
       }
       if (req.params.action === 'manual') {
@@ -48,7 +48,7 @@ module.exports = class AddressController extends BaseController {
               'storage-postcode',
               'postcodeApiMeta'
             ]);
-        if (req.params.id && req.params.id !== undefined) {
+        if (req.params.id !== undefined) {
           const storageAddresses = req.sessionModel.get('storageAddresses');
           const addresses = storageAddresses[req.params.id].address;
           const addressLines = addresses.split(', ').join('\n');

--- a/apps/new-dealer/controllers/storage-address.js
+++ b/apps/new-dealer/controllers/storage-address.js
@@ -39,9 +39,7 @@ module.exports = class AddressController extends BaseController {
   getValues(req, res, callback) {
     super.getValues(req, res, (err, values) => {
       if (err) {
-        // eslint-disable-next-line no-console
-        callback(err);
-        return callback(null, values);
+        return callback(err);
       }
       if (req.params.action === 'manual') {
             req.sessionModel.unset([

--- a/apps/new-dealer/controllers/storage-address.js
+++ b/apps/new-dealer/controllers/storage-address.js
@@ -62,9 +62,9 @@ module.exports = class AddressController extends BaseController {
   }
 
   saveValues(req, res, callback) {
-    let storageAddresses = req.sessionModel.get('storageAddresses') || {};
     const address = req.form.values['storage-address-manual'];
     const postcode = req.sessionModel.get('storage-postcode');
+    let storageAddresses = req.sessionModel.get('storageAddresses') || {};
     let id = req.params.id;
     if (id === undefined) {
       const currentIndex = req.sessionModel.get('currentIndex') || 0;

--- a/apps/new-dealer/controllers/storage-address.js
+++ b/apps/new-dealer/controllers/storage-address.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const BaseController = require('hof').controllers.base;
+const _ = require('lodash');
+
+module.exports = class AddressController extends BaseController {
+  locals(req, res, callback) {
+    const isManual = req.params.action === 'manual';
+    const locals = super.locals(req, res, callback);
+    const postcode = req.sessionModel.get('storage-postcode');
+    const addresses = req.sessionModel.get('storageAddresses');
+    const hasStorageAddresses = req.sessionModel.get('storageAddresses') ? true : false;
+    const storageAddresses = [];
+    _.forEach(addresses, (value, key) => {
+      const address = {
+        id: key,
+        address: value.address
+      };
+      storageAddresses.push(address);
+    });
+    return Object.assign({}, locals, {
+      storageAddresses,
+      hasStorageAddresses,
+      postcode,
+      postcodeApiMessageKey: isManual ? '' : (req.sessionModel.get('postcodeApiMeta') || {}).messageKey
+    });
+  }
+
+  getBackLink(req, res, callback) {
+    const backLink = super.getBackLink(req, res, callback);
+    if (req.params.id && req.params.id !== undefined) {
+      const id = req.params.id;
+      const back = req.params.action === 'edit' ? `${backLink}/${id}` : `${backLink}/edit/${id}`;
+      return back;
+    }
+    return backLink;
+  }
+
+  getValues(req, res, callback) {
+    super.getValues(req, res, (err, values) => {
+      if (err) {
+        // eslint-disable-next-line no-console
+        console.error(err);
+        return callback(null, values);
+      }
+      if (req.params.action === 'manual') {
+            req.sessionModel.unset([
+              'storage-postcode',
+              'postcodeApiMeta'
+            ]);
+        if (req.params.id && req.params.id !== undefined) {
+          const storageAddresses = req.sessionModel.get('storageAddresses');
+          const addresses = storageAddresses[req.params.id].address;
+          const addressLines = addresses.split(', ').join('\n');
+          return callback(null, Object.assign({}, values, {
+            'storage-address-manual': addressLines
+          }));
+        }
+      }
+      return callback(null, values);
+    });
+  }
+
+  saveValues(req, res, callback) {
+    let storageAddresses = req.sessionModel.get('storageAddresses') || {};
+    const address = req.form.values['storage-address-manual'];
+    const postcode = req.sessionModel.get('storage-postcode');
+    let id = req.params.id;
+    if (id === undefined) {
+      const currentIndex = req.sessionModel.get('currentIndex') || 0;
+      id = parseInt(currentIndex, 10);
+      req.sessionModel.set('currentIndex', id + 1);
+    }
+    storageAddresses[id] = {
+      address,
+      postcode
+    };
+    req.sessionModel.set({storageAddresses});
+    req.sessionModel.unset('storage-postcode');
+    super.saveValues(req, res, callback);
+  }
+};

--- a/apps/new-dealer/controllers/storage-postcode.js
+++ b/apps/new-dealer/controllers/storage-postcode.js
@@ -28,9 +28,7 @@ module.exports = class StoragePostcodeController extends BaseController {
   getValues(req, res, callback) {
     super.getValues(req, res, (err, values) => {
       if (err) {
-        // eslint-disable-next-line no-console
-        callback(err);
-        return callback(null, values);
+        return callback(err);
       }
       if (req.params.action === 'edit') {
         const address = values.storageAddresses[req.params.id];

--- a/apps/new-dealer/controllers/storage-postcode.js
+++ b/apps/new-dealer/controllers/storage-postcode.js
@@ -29,7 +29,7 @@ module.exports = class StoragePostcodeController extends BaseController {
     super.getValues(req, res, (err, values) => {
       if (err) {
         // eslint-disable-next-line no-console
-        console.error(err);
+        callback(err);
         return callback(null, values);
       }
       if (req.params.action === 'edit') {

--- a/apps/new-dealer/controllers/storage-postcode.js
+++ b/apps/new-dealer/controllers/storage-postcode.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const controllers = require('hof').controllers;
+const BaseController = controllers.base;
+const PostcodesModel = require('../models/postcodes');
+const _ = require('lodash');
+
+module.exports = class StoragePostcodeController extends BaseController {
+  locals(req, res, callback) {
+    const locals = super.locals(req, res, callback);
+    const addresses = req.sessionModel.get('storageAddresses');
+    const hasStorageAddresses = req.sessionModel.get('storageAddresses') ? true : false;
+    const storageAddresses = [];
+    _.forEach(addresses, (value, key) => {
+      const address = {
+        id: key,
+        address: value.address
+      };
+      storageAddresses.push(address);
+    });
+    let id = '';
+    if (req.params.action === 'edit') {
+      id = req.params.id;
+    }
+    return Object.assign({}, locals, {storageAddresses, hasStorageAddresses, id});
+  }
+
+  getValues(req, res, callback) {
+    super.getValues(req, res, (err, values) => {
+      if (err) {
+        // eslint-disable-next-line no-console
+        console.error(err);
+        return callback(null, values);
+      }
+      if (req.params.action === 'edit') {
+        const address = values.storageAddresses[req.params.id];
+        this.addressId = req.params.id;
+        return callback(null, Object.assign({}, values, {
+          'storage-postcode': address.postcode
+        }));
+      }
+      this.addressId = '';
+      return callback(null, values);
+    });
+  }
+
+  saveValues(req, res, cb) {
+    const saveValues = super.saveValues(req, res, cb);
+    this.postcodeChanged = req.form.values['storage-postcode'] !== req.sessionModel.get('storage-postcode');
+    return saveValues;
+  }
+
+  getNextStep(req, res) {
+    const nextStep = super.getNextStep(req, res);
+    if (req.method === 'POST') {
+      return `${nextStep}/${this.addressId}`;
+    }
+    return nextStep;
+  }
+
+  process(req, res, callback) {
+    const postcode = req.form.values['storage-postcode'];
+    const previousPostcode = req.sessionModel.get('storage-postcode');
+    if (!postcode
+      || previousPostcode && previousPostcode === postcode) {
+      return callback();
+    }
+
+    if (_.startsWith(postcode, 'BT')) {
+      req.sessionModel.unset('postcodeApiMeta');
+      req.sessionModel.unset('storage-addresses');
+      return callback();
+    }
+
+    const postcodesModel = new PostcodesModel();
+    postcodesModel.fetch(postcode)
+      .then(data => {
+        if (data.length) {
+          req.sessionModel.set('storage-addresses', data);
+        } else {
+          req.sessionModel.unset('storage-addresses');
+          req.sessionModel.set('postcodeApiMeta', {
+            messageKey: 'not-found'
+          });
+        }
+        return callback();
+      })
+      .catch(err => {
+        req.sessionModel.set('postcodeApiMeta', {
+          messageKey: 'cant-connect'
+        });
+        // eslint-disable-next-line no-console
+        console.error('Postcode lookup error: ',
+          `Code: ${err.status}; Detail: ${err.detail}`);
+        return callback();
+      });
+  }
+};

--- a/apps/new-dealer/controllers/storage-postcode.js
+++ b/apps/new-dealer/controllers/storage-postcode.js
@@ -59,6 +59,7 @@ module.exports = class StoragePostcodeController extends BaseController {
   }
 
   process(req, res, callback) {
+    const postcodesModel = new PostcodesModel();
     const postcode = req.form.values['storage-postcode'];
     const previousPostcode = req.sessionModel.get('storage-postcode');
     if (!postcode
@@ -72,7 +73,6 @@ module.exports = class StoragePostcodeController extends BaseController {
       return callback();
     }
 
-    const postcodesModel = new PostcodesModel();
     postcodesModel.fetch(postcode)
       .then(data => {
         if (data.length) {

--- a/apps/new-dealer/fields/index.js
+++ b/apps/new-dealer/fields/index.js
@@ -641,5 +641,13 @@ module.exports = {
       attribute: 'height',
       value: 6
     }]
+  },
+  'storage-add-another-address': {
+    mixin: 'radio-group',
+    validate: 'required',
+    options: [
+      'yes',
+      'no'
+    ]
   }
 };

--- a/apps/new-dealer/translations/src/en/fields.json
+++ b/apps/new-dealer/translations/src/en/fields.json
@@ -519,5 +519,16 @@
   },
   "contact-address-lookup": {
     "label": "Select your address"
+  },
+  "storage-add-another-address": {
+    "legend": "The police will inspect each address used for storage",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
   }
 }

--- a/apps/new-dealer/translations/src/en/pages.json
+++ b/apps/new-dealer/translations/src/en/pages.json
@@ -155,5 +155,20 @@
   },
   "contact-address": {
     "header": "What is {{values.someone-else-name}}'s address?"
+  },
+  "storage-add-another-address": {
+    "header": {
+      "weapons-ammunition": {
+        "weapons": "Is there another address where the prohibited weapons/component parts be stored?",
+        "weapons,ammunition": {
+          "storage-weapons-ammo": {
+            "weapons": "Is there another address where the prohibited weapons/component parts be stored?",
+            "weapons,ammunition": "Is there another address where the prohibited weapons/component parts and ammunition be stored?",
+            "ammunition": "Is there another address where the prohibited ammunition be stored?"
+          }
+        },
+        "ammunition": "Is there another address where the prohibited ammunition be stored?"
+      }
+    }
   }
 }

--- a/apps/new-dealer/translations/src/en/validation.json
+++ b/apps/new-dealer/translations/src/en/validation.json
@@ -222,6 +222,9 @@
   "storage-address-lookup": {
     "required": "Select an address"
   },
+  "storage-add-another-address": {
+    "required": "Select an option"
+  },
   "contact-email": {
     "required": "Enter contact's email address",
     "email": "Enter a valid email address"

--- a/apps/new-dealer/views/partials/storage-address-summary.html
+++ b/apps/new-dealer/views/partials/storage-address-summary.html
@@ -1,0 +1,8 @@
+{{#hasStorageAddresses}}
+  <div id="storage-address-summary">
+    <h2>Addresses added</h2>
+    {{#storageAddresses}}
+      <p class="address-summary">{{address}} <span class="link"><a href="{{baseUrl}}/storage-postcode/edit/{{id}}">Change</a></span></p>
+    {{/storageAddresses}}
+  </div>
+{{/hasStorageAddresses}}

--- a/apps/new-dealer/views/storage-add-another-address.html
+++ b/apps/new-dealer/views/storage-add-another-address.html
@@ -1,0 +1,9 @@
+{{<partials-page}}
+  {{$page-content}}
+    {{#fields}}
+      {{#renderField}}{{/renderField}}
+    {{/fields}}
+    {{#input-submit}}continue{{/input-submit}}
+    {{<partials-storage-address-summary}}{{/partials-storage-address-summary}}
+  {{/page-content}}
+{{/partials-page}}

--- a/apps/new-dealer/views/storage-address-lookup.html
+++ b/apps/new-dealer/views/storage-address-lookup.html
@@ -1,0 +1,19 @@
+{{<partials-page}}
+  {{$page-content}}
+    <label>
+      {{#t}}fields.storage-postcode.label{{/t}}
+    </label>
+    <p>
+      <span class="postcode">{{postcode}}</span>
+      <span class="link"><a href="{{baseUrl}}/storage-postcode{{#id}}/edit/{{id}}{{/id}}">{{#t}}pages.address.edit{{/t}}</a></span>
+    </p>
+
+    {{#select}}storage-address-lookup{{/select}}
+
+    <p><span id="cant-find" class="link"><a href="{{baseUrl}}/storage-address{{#id}}/edit/{{id}}{{/id}}">{{#t}}pages.address.cantfind{{/t}}</a></span></p>
+
+    {{#input-submit}}continue{{/input-submit}}
+
+    {{<partials-storage-address-summary}}{{/partials-storage-address-summary}}
+  {{/page-content}}
+{{/partials-page}}

--- a/apps/new-dealer/views/storage-address.html
+++ b/apps/new-dealer/views/storage-address.html
@@ -1,0 +1,27 @@
+{{<partials-page}}
+  {{$page-content}}
+    {{#postcode}}
+      <label>
+        {{#t}}fields.storage-postcode.label{{/t}}
+      </label>
+      <p>
+        <span class="postcode">{{postcode}}</span>
+        <span class="link"><a href="{{baseUrl}}/storage-postcode">{{#t}}pages.address.edit{{/t}}</a></span>
+      </p>
+    {{/postcode}}
+    {{#postcodeApiMessageKey}}
+      <div class="alert-info">
+              <span class="info-message">
+                {{#t}}pages.address.postcode-api.{{postcodeApiMessageKey}}{{/t}}
+              </span>
+      </div>
+    {{/postcodeApiMessageKey}}
+    {{#fields}}
+      {{#renderField}}{{/renderField}}
+    {{/fields}}
+    {{#input-submit}}continue{{/input-submit}}
+
+    {{<partials-storage-address-summary}}{{/partials-storage-address-summary}}
+
+  {{/page-content}}
+{{/partials-page}}

--- a/apps/new-dealer/views/storage-address.html
+++ b/apps/new-dealer/views/storage-address.html
@@ -11,9 +11,9 @@
     {{/postcode}}
     {{#postcodeApiMessageKey}}
       <div class="alert-info">
-              <span class="info-message">
-                {{#t}}pages.address.postcode-api.{{postcodeApiMessageKey}}{{/t}}
-              </span>
+        <span class="info-message">
+          {{#t}}pages.address.postcode-api.{{postcodeApiMessageKey}}{{/t}}
+        </span>
       </div>
     {{/postcodeApiMessageKey}}
     {{#fields}}

--- a/apps/new-dealer/views/storage-postcode.html
+++ b/apps/new-dealer/views/storage-postcode.html
@@ -1,0 +1,15 @@
+{{<partials-page}}
+  {{$page-content}}
+    {{#fields}}
+      {{#renderField}}{{/renderField}}
+    {{/fields}}
+      <p>
+        <span class="link">
+          <a id='manual-entry' href="{{baseUrl}}/storage-address/manual{{#id}}/{{id}}{{/id}}">{{#t}}pages.postcode.manual{{/t}}</a>
+        </span>
+      </p>
+    {{#input-submit}}continue{{/input-submit}}
+
+    {{<partials-storage-address-summary}}{{/partials-storage-address-summary}}
+  {{/page-content}}
+{{/partials-page}}

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -72,3 +72,23 @@ span.postcode {
 summary.summary-details {
   margin-bottom: 20px;
 }
+
+#storage-address-summary {
+  border: 5px solid #dee0e2;
+  margin-top: 30px;
+  padding: 20px 15px 0 15px;
+
+  h2 {
+    margin-top: 0;
+  }
+
+  .address-summary {
+    font-size: 16px;
+    border-bottom: 1px solid #bfc1c3;
+    padding-bottom: 5px;
+  }
+
+  .link {
+    float: right;
+  }
+}

--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -31,7 +31,6 @@ module.exports = {
     secondAuthorityHoldersAddressPage: pagesPath('second-authority-holders-address.js'),
     storageWeaponsAndAmmoPage: pagesPath('storage-weapons-ammo.js'),
     storageAddressPage: pagesPath('storage-address.js'),
-    storageAnotherAddressPage: pagesPath('storage-add-another-address.js'),
     contactPage: pagesPath('contact.js'),
     contactDetailsPage: pagesPath('contact-details.js'),
     contactAddressPage: pagesPath('contact-address.js'),


### PR DESCRIPTION
This step is to allow the user to add multiple addresses whilst using the same steps to loop over.

What is basically happening is, when we get to the address-lookup step or manual-address step, we are adding the address to an array along with an id and then clearing the fields in order to go around again.

When the user has added an address, the address will appear on the add-another-address step where they are able to change the address, add more or continue.

If the user chooses to add another address, they are taken to the storage-postcode step where they can do the process again. The user will be able to see the addresses the have added just like the add-another-address step. See prototype -> https://s5-firearms-application.herokuapp.com/apply/storage-address-add

If the user chooses to change the address, then they are taken to the storage-postcode step with the fields entered with the relevant data. The url is appended with /edit/${id}. The id allows us to get the relevant data to fill the fields and allows us to overwrite the old address with the new one in the array.

When the user clicks back on the add-another-address step, then the user is taken back to the postcode-lookup with the url appended with /edit/${id}

As well as this, the usual step components have been added:
	* The steps have been added to the routes config,
	* The fields have been added to the fields config,
	* Controllers have been added for the steps,
	* The translations have been added for the page, fields and validation,
	* Custom html templates have been created,
	* Acceptance tests have been updated for storage-address including the page-object.