### PR TITLE
flho-297 Changes to the obtain step.

### DIFF
--- a/apps/new-dealer/acceptance/features/obtain.js
+++ b/apps/new-dealer/acceptance/features/obtain.js
@@ -32,52 +32,16 @@ Scenario('An error is shown if obtain step is not completed', (
   I.seeErrors(obtainPage['obtain-group']);
 });
 
-Scenario('Selecting Buy toggles further details field', (
-  obtainPage
-) => {
-    obtainPage.checkboxTogglesField(obtainPage.buy, obtainPage['further-details'].buy);
-});
-
-Scenario('Selecting Take temporary possession toggles further details field', (
-  obtainPage
-) => {
-  obtainPage.checkboxTogglesField(obtainPage['temporary-possession'], obtainPage['further-details']['temporary-possession']);
-});
-
 Scenario('Selecting Acquire through other means toggles further details field', (
   obtainPage
 ) => {
   obtainPage.checkboxTogglesField(obtainPage['other-means'], obtainPage['further-details']['other-means']);
 });
 
-Scenario('Selecting Won\'t take possession toggles further details field', (
-  obtainPage
-) => {
-  obtainPage.checkboxTogglesField(obtainPage['wont-take-possession'], obtainPage['further-details']['wont-take-possession']);
-});
-
-Scenario('An error is shown if obtain step is not completed after selecting Buy', (
-  obtainPage
-) => {
-  obtainPage.toggledFieldShowsError(obtainPage.buy, obtainPage['further-details'].buy);
-});
-
-Scenario('An error is shown if obtain step is not completed after selecting Take temporary possession', (
-  obtainPage
-) => {
-  obtainPage.toggledFieldShowsError(obtainPage['temporary-possession'], obtainPage['further-details']['temporary-possession']);
-});
-
 Scenario('An error is shown if obtain step is not completed after selecting Acquire through other means', (
   obtainPage
 ) => {
   obtainPage.toggledFieldShowsError(obtainPage['other-means'], obtainPage['further-details']['other-means']);
-});
-
-Scenario('An error is shown if obtain step is not completed after selecting Won\'t take possession', (
-  obtainPage
-) => {
-  obtainPage.toggledFieldShowsError(obtainPage['wont-take-possession'], obtainPage['further-details']['wont-take-possession']);
 });
 
 Scenario('Im taken to the storage step', (

--- a/apps/new-dealer/acceptance/pages/obtain.js
+++ b/apps/new-dealer/acceptance/pages/obtain.js
@@ -40,7 +40,6 @@ module.exports = {
 
   fillFormAndSubmit() {
     I.click(this.buy);
-    I.fillField(this['further-details'].buy, this.content.buy);
     I.submitForm();
   }
 };

--- a/apps/new-dealer/fields/index.js
+++ b/apps/new-dealer/fields/index.js
@@ -126,54 +126,24 @@ module.exports = {
     mixin: 'checkbox-group',
     validate: 'required',
     options: [{
-      value: 'buy',
-      toggle: 'buy-details',
-      child: 'partials/obtain-buy'
+      value: 'buy'
     }, {
-      value: 'temporary-possession',
-      toggle: 'temporary-details',
-      child: 'textarea'
+      value: 'temporary-possession'
     }, {
       value: 'manufacture'
+    }, {
+      value: 'wont-take-possession'
     }, {
       value: 'other-means',
       toggle: 'other-means-details',
       child: 'textarea'
-    }, {
-      value: 'wont-take-possession',
-      toggle: 'wont-take-details',
-      child: 'textarea'
     }]
-  },
-  'buy-details': {
-    validate: 'required',
-    dependent: {
-      field: 'obtain',
-      value: 'buy'
-    }
-  },
-  'buy-import': {
-    className: 'form-checkbox'
-  },
-  'temporary-details': {
-    validate: 'required',
-    dependent: {
-      field: 'obtain',
-      value: 'temporary-possession'
-    }
   },
   'other-means-details': {
     validate: 'required',
     dependent: {
       field: 'obtain',
       value: 'other-means'
-    }
-  },
-  'wont-take-details': {
-    validate: 'required',
-    dependent: {
-      field: 'obtain',
-      value: 'wont-take-possession'
     }
   },
   'stored-on-premises': {

--- a/apps/new-dealer/fields/index.js
+++ b/apps/new-dealer/fields/index.js
@@ -125,19 +125,17 @@ module.exports = {
   obtain: {
     mixin: 'checkbox-group',
     validate: 'required',
-    options: [{
-      value: 'buy'
-    }, {
-      value: 'temporary-possession'
-    }, {
-      value: 'manufacture'
-    }, {
-      value: 'wont-take-possession'
-    }, {
-      value: 'other-means',
-      toggle: 'other-means-details',
-      child: 'textarea'
-    }]
+    options: [
+      'buy',
+      'temporary-possession',
+      'manufacture',
+      'wont-take-possession',
+      {
+        value: 'other-means',
+        toggle: 'other-means-details',
+        child: 'textarea'
+      }
+    ]
   },
   'other-means-details': {
     validate: 'required',

--- a/apps/new-dealer/index.js
+++ b/apps/new-dealer/index.js
@@ -61,11 +61,7 @@ module.exports = {
     '/obtain': {
       fields: [
         'obtain',
-        'buy-details',
-        'buy-import',
-        'temporary-details',
-        'other-means-details',
-        'wont-take-details'
+        'other-means-details'
       ],
       next: '/storage'
     },

--- a/apps/new-dealer/translations/src/en/fields.json
+++ b/apps/new-dealer/translations/src/en/fields.json
@@ -95,20 +95,8 @@
       }
     }
   },
-  "buy-details": {
-    "label": "Please provide further details, including which companies will the prohibited items be bought from"
-  },
-  "buy-import": {
-    "label": "Tick this box if the prohibited items will be imported"
-  },
-  "temporary-details": {
-    "label": "Please provide further details"
-  },
   "other-means-details": {
     "label": "How will the prohibited items be acquired?"
-  },
-  "wont-take-details": {
-    "label": "Please provide further details"
   },
   "stored-on-premises": {
     "options": {

--- a/apps/new-dealer/translations/src/en/validation.json
+++ b/apps/new-dealer/translations/src/en/validation.json
@@ -41,16 +41,7 @@
   "obtain": {
     "required": "Select at least one option"
   },
-  "buy-details": {
-    "required": "Provide further details"
-  },
-  "temporary-details": {
-    "required": "Provide further details"
-  },
   "other-means-details": {
-    "required": "Provide further details"
-  },
-  "wont-take-details": {
     "required": "Provide further details"
   },
   "stored-on-premises": {

--- a/apps/new-dealer/views/partials/obtain-buy.html
+++ b/apps/new-dealer/views/partials/obtain-buy.html
@@ -1,6 +1,0 @@
-<div id="buy-details-panel" class="reveal" aria-hidden="false">
-  <div class="panel-indent">
-    {{#textarea}}buy-details{{/textarea}}
-    {{#checkbox}}buy-import{{/checkbox}}
-  </div>
-</div>


### PR DESCRIPTION
	* Removed toggled text boxes for buy, temp-possession and wont-be-in-possession options,
	* Moved option acquire through other means to the bottom of the options,
	* Removed toggled fields from fields config and route config,
	* Removed translations for fields
	* Removed some tests that aren't needed any more