### PR TITLE
flho-338 Added the customer confirmation email

### DIFF
--- a/apps/new-dealer/acceptance/features/company-name.js
+++ b/apps/new-dealer/acceptance/features/company-name.js
@@ -124,21 +124,21 @@ Scenario('An error is shown if company-name step is not completed after selectin
   I.seeErrors(companyNamePage['museum-name']);
 });
 
-Scenario('Selecting other toggles other-specify field', (
+Scenario('Selecting other toggles other-name field', (
   I,
   companyNamePage
 ) => {
-  I.checkOption(companyNamePage['other']);
-  I.seeElements(companyNamePage['other-specify']);
+  I.checkOption(companyNamePage.other);
+  I.seeElements(companyNamePage['other-name']);
 });
 
 Scenario('An error is shown if company-name step is not completed after selecting other', (
   I,
   companyNamePage
 ) => {
-  I.checkOption(companyNamePage['other']);
+  I.checkOption(companyNamePage.other);
   I.submitForm();
-  I.seeErrors(companyNamePage['other-specify']);
+  I.seeErrors(companyNamePage['other-name']);
 });
 
 Scenario('Im taken to the handle step', (

--- a/apps/new-dealer/acceptance/pages/company-name.js
+++ b/apps/new-dealer/acceptance/pages/company-name.js
@@ -23,7 +23,7 @@ module.exports = {
   museum: '#organisation-museum',
   'museum-name': '#museum-name',
   other: '#organisation-other',
-  'other-specify': '#other-specify',
+  'other-name': '#other-name',
 
   content: {
     name: 'Four-Five-Six Laundry',

--- a/apps/new-dealer/controllers/confirm.js
+++ b/apps/new-dealer/controllers/confirm.js
@@ -1,7 +1,8 @@
 'use strict';
 
-const controllers = require('hof-controllers').confirm;
 const _ = require('lodash');
+const path = require('path');
+const controllers = require('hof-controllers').confirm;
 
 module.exports = class ConfirmController extends controllers {
 
@@ -103,11 +104,17 @@ module.exports = class ConfirmController extends controllers {
     }
   }
 
-  addContactDetailsSection(req) {
+  getContactHoldersName(req) {
     const contactHolder = req.sessionModel.get('contact-holder');
     const contactName = contactHolder === 'first' || contactHolder === 'second' ?
       req.sessionModel.get(`${contactHolder}-authority-holders-name`) :
       req.sessionModel.get('someone-else-name');
+    return contactName;
+  }
+
+  addContactDetailsSection(req) {
+    const contactHolder = req.sessionModel.get('contact-holder');
+    const contactName = this.getContactHoldersName(req);
     const contactAddress = req.sessionModel.get(`${contactHolder}-authority-holders-address-manual`);
     this.formattedData = this.formattedData.map(section => {
       if (section.fields !== undefined) {
@@ -122,6 +129,29 @@ module.exports = class ConfirmController extends controllers {
         });
       }
       return section;
+    });
+  }
+
+  getEmailerConfig(req) {
+    const config = super.getEmailerConfig(req);
+    const organisation = req.sessionModel.get('organisation');
+    const customViews = path.resolve(__dirname, '../views/email/');
+    const greeting = `${req.translate('pages.email.greeting')} ${this.getContactHoldersName(req)}`;
+    config.customerIntro = [greeting].concat(config.customerIntro);
+    const data = {
+      organisation: req.sessionModel.get(`${organisation}-name`),
+      date: (new Date()).toUTCString()
+    };
+    if (req.sessionModel.get('activity') === 'renew') {
+      data.reference = req.sessionModel.get('reference-number');
+    }
+    const emailData = _.map(data, (value, index) => ({
+      subheader: req.translate(`pages.email.data.${index}`),
+      value
+    }));
+    config.data.push({emailData});
+    return Object.assign({}, config, {
+      customViews
     });
   }
 };

--- a/apps/new-dealer/fields/index.js
+++ b/apps/new-dealer/fields/index.js
@@ -44,7 +44,7 @@ module.exports = {
       child: 'input-text'
     }, {
       value: 'other',
-      toggle: 'other-specify',
+      toggle: 'other-name',
       child: 'input-text'
     }]
   },
@@ -97,7 +97,7 @@ module.exports = {
       value: 'museum'
     }
   },
-  'other-specify': {
+  'other-name': {
     validate: 'required',
     dependent: {
       field: 'organisation',

--- a/apps/new-dealer/index.js
+++ b/apps/new-dealer/index.js
@@ -46,7 +46,7 @@ module.exports = {
         'charity-name',
         'charity-number',
         'museum-name',
-        'other-specify'
+        'other-name'
       ],
       next: '/handle',
       locals: {
@@ -558,8 +558,9 @@ module.exports = {
       fields: [
         'declaration'
       ],
-      fieldsConfig: require('./fields'),
+      customerEmailField: 'contact-email',
       emailConfig: require('../../config').email,
+      fieldsConfig: require('./fields'),
       next: '/confirmation'
     },
     '/confirmation': {

--- a/apps/new-dealer/translations/src/en/fields.json
+++ b/apps/new-dealer/translations/src/en/fields.json
@@ -49,8 +49,8 @@
   "museum-name": {
     "label": "Museum name"
   },
-  "other-specify": {
-    "label": "Other specify"
+  "other-name": {
+    "label": "Organisation name"
   },
   "weapons-ammunition": {
     "legend": "Select all that apply",

--- a/apps/new-dealer/translations/src/en/pages.json
+++ b/apps/new-dealer/translations/src/en/pages.json
@@ -202,8 +202,32 @@
   },
   "email": {
     "subject": {
-      "caseworker": "test",
-      "customer": "test"
+      "customer": "Your email confirmation - application to handle prohibited weapons, component parts or ammunition"
+    },
+    "greeting": "Dear",
+    "data": {
+      "organisation": "Business name",
+      "date": "Date of application",
+      "reference": "Customer reference number"
+    },
+    "intro": {
+      "customer": [
+        "This email confirms receipt of your application to handle prohibited weapons, component parts or ammunition. We will review the application, and get back to you at this email address if we require further information.",
+        "If sufficient information and suitable evidence has been provided, we’ll instruct the local police force to make enquiries on behalf of the Secretary of State. In this case, the police will contact you regarding security inspections and interviews.",
+        "The decision on your application is pending. This email is not a certificate of authority."
+      ]
+    },
+    "outro": {
+      "customer": [
+        "If you need to contact us about this application, or believe you have received this email by mistake, contact the Home Office's firearms licensing unit using the details below.",
+        "Firearms Licensing Unit",
+        "Home Office",
+        "2 Marsham Street",
+        "London",
+        "SW1P 4DF",
+        "Email: firearms.applications@homeoffice.gsi.gov.uk",
+        "Tel: 020 7035 3538"
+      ]
     }
   },
   "confirmation": {

--- a/apps/new-dealer/translations/src/en/validation.json
+++ b/apps/new-dealer/translations/src/en/validation.json
@@ -29,8 +29,8 @@
   "museum-name": {
     "required": "Enter the museum name"
   },
-  "other-specify": {
-    "required": "Specify the type of organisation"
+  "other-name": {
+    "required": "Specify the name of the organisation"
   },
   "weapons-ammunition": {
     "required": "Select what the company will handle"

--- a/apps/new-dealer/views/email/formatted.html
+++ b/apps/new-dealer/views/email/formatted.html
@@ -1,0 +1,14 @@
+{{<layout}}
+  {{$email-content}}
+    {{#data}}
+      {{#emailData}}
+      <tr style="border-top: 1px solid #009390;">
+        <td width="100%" colspan="2"><p style="font-size: 16px; font-weight: bold; color: #000; margin: 10px 0;">{{subheader}}</p></td>
+      </tr>
+      <tr style="border-top: 1px solid #009390;">
+        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0; white-space: pre-wrap;">{{value}}</p></td>
+      </tr>
+      {{/emailData}}
+    {{/data}}
+  {{/email-content}}
+{{/layout}}

--- a/apps/new-dealer/views/email/raw.html
+++ b/apps/new-dealer/views/email/raw.html
@@ -1,0 +1,12 @@
+{{subject}}
+{{#intro}}
+  {{.}}
+{{/intro}}
+{{#data}}
+  {{#emailData}}
+    {{subheader}}: {{value}}
+  {{/emailData}}
+{{/data}}
+{{#outro}}
+  {{.}}
+{{/outro}}

--- a/config.js
+++ b/config.js
@@ -14,12 +14,15 @@ module.exports = {
     }
   },
   email: {
-    caseworker: process.env.CASEWORKER_EMAIL || '',
     from: process.env.FROM_ADDRESS || '',
     replyTo: process.env.REPLY_TO || '',
     accessKeyId: process.env.AWS_USER || '',
     secretAccessKey: process.env.AWS_PASSWORD || '',
-    transportType: 'ses',
-    region: process.env.EMAIL_REGION || ''
+    transportType: process.env.EMAIL_TRANSPORT,
+    region: process.env.EMAIL_REGION || '',
+    ignoreTLS: process.env.IGNORE_TLS === 'true',
+    secure: process.env.EMAIL_SECURE === 'true',
+    port: process.env.EMAIL_PORT || '',
+    host: process.env.EMAIL_HOST || '',
   }
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,18 @@ services:
   app:
     build: .
     environment:
-      - NODE_ENV=docker-compose
+      - NODE_ENV=development
+      - EMAIL_TRANSPORT=smtp
+      - EMAIL_HOST=maildev
+      - CASEWORKER_EMAIL=caseworker@gov.uk.test
+      - IGNORE_TLS=true
+      - EMAIL_SECURE=false
+      - EMAIL_PORT=25
       - REDIS_HOST=redis
       - REDIS_PORT=6379
     links:
       - redis
+      - maildev
     ports:
       - "8080:8080"
     volumes:
@@ -30,3 +37,9 @@ services:
       - app
     volumes_from:
       - app
+
+  maildev:
+    image: djfarrelly/maildev
+    ports:
+      - "8000:80"
+      - "25"


### PR DESCRIPTION
* On the organisation step, changed the field other-specify to other-name as the email will show the organisation name,
* Changed the acceptance tests to reflect this change,
* In the confirm controller: 
                    - Moved the getting of the contact name into it's own function. 
                    - Added a getEmailConfig function. This gets some data (organisation name, contact name, reference number) and adds it to the config. 
                    - Adjust the intro text to greet the contact holder and use the contact's name.
* Change the confirm route config to send email to the contact's email address,
* Added the email text to the pages translations file,
* Created two email templates raw and formatted,
* Adjusted the config to send email,
* Added env variables to the docker-compose file