### PR TITLE
Address-lookup Change link on Confirm page bug

### DIFF
--- a/apps/common/controllers/address-lookup.js
+++ b/apps/common/controllers/address-lookup.js
@@ -30,10 +30,8 @@ module.exports = class AddressLookup extends BaseController {
 
   saveValues(req, res, callback) {
     const field = this.options.locals.field;
-    const addressLines = req.form.values[`${field}-address-lookup`].split(', ').join('\n');
-    req.sessionModel.set(`${field}-address-manual`, addressLines);
+    req.form.values[`${field}-address-lookup`] = req.form.values[`${field}-address-lookup`].split(', ').join('\n');
     req.sessionModel.unset('addresses');
-
     super.saveValues(req, res, callback);
   }
 

--- a/apps/new-dealer/fields/index.js
+++ b/apps/new-dealer/fields/index.js
@@ -534,8 +534,7 @@ module.exports = {
     includeInSummary: false
   },
   'first-authority-holders-address-lookup': {
-    className: 'address',
-    includeInSummary: false
+    className: 'address'
   },
   'first-authority-holders-address-manual': {
     mixin: 'textarea',
@@ -574,8 +573,7 @@ module.exports = {
     includeInSummary: false
   },
   'second-authority-holders-address-lookup': {
-    className: 'address',
-    includeInSummary: false
+    className: 'address'
   },
   'second-authority-holders-address-manual': {
     mixin: 'textarea',
@@ -653,8 +651,7 @@ module.exports = {
     includeInSummary: false
   },
   'authority-holder-contact-address-lookup': {
-    className: 'address',
-    includeInSummary: false
+    className: 'address'
   },
   'authority-holder-contact-address-manual': {
     mixin: 'textarea',
@@ -673,8 +670,7 @@ module.exports = {
     includeInSummary: false
   },
   'contact-address-lookup': {
-    className: 'address',
-    includeInSummary: false
+    className: 'address'
   },
   'contact-address-manual': {
     mixin: 'textarea',

--- a/apps/new-dealer/translations/src/en/fields.json
+++ b/apps/new-dealer/translations/src/en/fields.json
@@ -375,6 +375,7 @@
     "label": "Address"
   },
   "first-authority-holders-address-lookup": {
+    "summary": "Home address",
     "label": "Select your address"
   },
   "second-authority-dob": {
@@ -414,10 +415,11 @@
     "label": "Postcode"
   },
   "second-authority-holders-address-manual": {
-    "summary": "Address",
+    "summary": "Home Address",
     "label": "Address"
   },
   "second-authority-holders-address-lookup": {
+    "summary": "Home address",
     "label": "Select your address"
   },
   "contact-holder": {
@@ -467,6 +469,7 @@
     "label": "Postcode"
   },
   "authority-holder-contact-address-lookup": {
+    "summary": "Home address",
     "label": "Select your address"
   },
   "authority-holder-contact-address-manual": {
@@ -481,6 +484,7 @@
     "label": "Address"
   },
   "contact-address-lookup": {
+    "summary": "Home address",
     "label": "Select your address"
   },
   "storage-add-another-address": {


### PR DESCRIPTION
Fix bug where **if** the address-lookup select step is used instead of manual, the `Change` link on the confirm step would take the user to the incorrect step. 
Previously when selecting the address on the lookup we were also setting the manual address with that address and using the manual address field on the confirm step. However this was causing an error with the Change link and the correct step was not being added to the link. 
Now we do not set the manual address in the session and instead display the address-lookup.
Added summary translations for all the address-lookup fields and removed `includeInSummary: false` from each address-lookup field in the config.