### PR TITLE
REFACTOR: Move typeahead initialisation code into own module

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -10,67 +10,6 @@ helpers.documentReady(progressiveReveal);
 helpers.documentReady(formFocus);
 
 var $ = require('jquery');
-var typeahead = require('typeahead-aria');
-var Bloodhound = require('typeahead-aria').Bloodhound;
+var typeahead = require('./lib/typeahead');
 
-typeahead.loadjQueryPlugin();
-
-$('.typeahead').each(function applyTypeahead() {
-  var $el = $(this);
-  var $parent = $el.parent();
-  var attributes = $el.prop('attributes');
-  var $input = $('<input/>');
-  var selectedValue = $el.val();
-  var typeaheadList = $el.find('option').map(function mapOptions() {
-    if (this.value === '') {
-      return undefined;
-    }
-    return this.value;
-  }).get();
-
-  // remove the selectbox
-  $el.remove();
-
-  $.each(attributes, function applyAttributes() {
-    $input.attr(this.name, this.value);
-  });
-
-  $input.removeClass('js-hidden');
-  $input.addClass('form-control');
-  $input.val(selectedValue);
-
-  $parent.append($input);
-
-  $input.typeahead({
-    hint: false
-  }, {
-    source: new Bloodhound({
-      datumTokenizer: Bloodhound.tokenizers.whitespace,
-      queryTokenizer: Bloodhound.tokenizers.whitespace,
-      local: typeaheadList,
-      sorter: function sorter(a, b) {
-        var input = $input.val();
-        var startsWithInput = function startsWithInput(x) {
-          return x.toLowerCase().substr(0, input.length) === input.toLowerCase() ? -1 : 1;
-        };
-
-        var compareAlpha = function compareAlpha(x, y) {
-          var less = x < y ? -1 : 1;
-          return x === y ? 0 : less;
-        };
-
-        var compareStartsWithInput = function compareStartsWithInput(x, y) {
-          var startsWithFirst = startsWithInput(x);
-          var startsWithSecond = startsWithInput(y);
-
-          return startsWithFirst === startsWithSecond ? 0 : startsWithFirst;
-        };
-
-        var first = compareStartsWithInput(a, b);
-
-        return first === 0 ? compareAlpha(a, b) : first;
-      }
-    }),
-    limit: 100
-  });
-});
+$('.typeahead').each(typeahead);

--- a/assets/js/lib/typeahead.js
+++ b/assets/js/lib/typeahead.js
@@ -1,0 +1,69 @@
+'use strict';
+
+var $ = require('jquery');
+var typeahead = require('typeahead-aria');
+var Bloodhound = require('typeahead-aria').Bloodhound;
+
+typeahead.loadjQueryPlugin();
+
+function applyTypeahead() {
+  var $el = $(this);
+  var $parent = $el.parent();
+  var attributes = $el.prop('attributes');
+  var $input = $('<input/>');
+  var selectedValue = $el.val();
+  var typeaheadList = $el.find('option').map(function mapOptions() {
+    if (this.value === '') {
+      return undefined;
+    }
+    return this.value;
+  }).get();
+
+  // remove the selectbox
+  $el.remove();
+
+  $.each(attributes, function applyAttributes() {
+    $input.attr(this.name, this.value);
+  });
+
+  $input.removeClass('js-hidden');
+  $input.addClass('form-control');
+  $input.val(selectedValue);
+
+  $parent.append($input);
+
+  $input.typeahead({
+    hint: false
+  }, {
+    source: new Bloodhound({
+      datumTokenizer: Bloodhound.tokenizers.whitespace,
+      queryTokenizer: Bloodhound.tokenizers.whitespace,
+      local: typeaheadList,
+      sorter: function sorter(a, b) {
+        var input = $input.val();
+        var startsWithInput = function startsWithInput(x) {
+          return x.toLowerCase().substr(0, input.length) === input.toLowerCase() ? -1 : 1;
+        };
+
+        var compareAlpha = function compareAlpha(x, y) {
+          var less = x < y ? -1 : 1;
+          return x === y ? 0 : less;
+        };
+
+        var compareStartsWithInput = function compareStartsWithInput(x, y) {
+          var startsWithFirst = startsWithInput(x);
+          var startsWithSecond = startsWithInput(y);
+
+          return startsWithFirst === startsWithSecond ? 0 : startsWithFirst;
+        };
+
+        var first = compareStartsWithInput(a, b);
+
+        return first === 0 ? compareAlpha(a, b) : first;
+      }
+    }),
+    limit: 100
+  });
+}
+
+module.exports = applyTypeahead;


### PR DESCRIPTION
This helps to keep the index file clean by moving all the code to setup the typeahead elements into its own module.