### PR TITLE
Ensure translations are updated in dev mode when lang files change

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ pipeline:
     commands:
       - npm --loglevel warn install -g npm@3.10.8
       - npm --loglevel warn install
-      - npm run test:ci
+      - npm test
     when:
       event: [push, pull_request]
 
@@ -12,7 +12,7 @@ pipeline:
     image: node:5
     commands:
       - npm --loglevel warn install
-      - npm run test:ci
+      - npm test
     when:
       event: [push, pull_request]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ before_install:
   - docker run -d --net=host -e NODE_ENV=ci travis
 
 script:
-  - npm run test:ci && npm run test:acceptance
+  - npm test && npm run test:acceptance

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "watch:scss": "nodemon -e scss -x 'npm run sass'",
     "watch:js": "nodemon --watch assets/js -e js -x 'npm run browserify'",
     "test": "NODE_ENV=test npm run lint && istanbul cover _mocha",
-    "test:ci": "npm run test",
     "test:acceptance": "funkie so-acceptance --steps",
     "lint": "npm-run-all --parallel lint:app lint:acceptance",
     "lint:app": "eslint .",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "watch:app": "NODE_ENV=development nodemon -x 'npm run hof-transpile && npm start' --ignore 'apps/**/translations/en/'",
     "watch:scss": "nodemon -e scss -x 'npm run sass'",
     "watch:js": "nodemon --watch assets/js -e js -x 'npm run browserify'",
-    "watch:translations": "nodemon --watch apps/**/translations/src -x 'npm run hof-transpile'",
     "test": "NODE_ENV=test npm run lint && istanbul cover _mocha",
     "test:ci": "npm run test",
     "test:acceptance": "funkie so-acceptance --steps",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "readme": "./README.md",
   "scripts": {
     "start": "node .",
-    "dev": "npm-run-all --parallel watch:app watch:scss watch:js watch:translations",
-    "watch:app": "NODE_ENV=development nodemon .",
+    "dev": "npm-run-all --parallel watch:app watch:scss watch:js",
+    "watch:app": "NODE_ENV=development nodemon -x 'npm run hof-transpile && npm start' --ignore 'apps/**/translations/en/'",
     "watch:scss": "nodemon -e scss -x 'npm run sass'",
     "watch:js": "nodemon --watch assets/js -e js -x 'npm run browserify'",
     "watch:translations": "nodemon --watch apps/**/translations/src -x 'npm run hof-transpile'",


### PR DESCRIPTION
The previous setup meant that the lang files were compiled when files changed, but did not trigger a restart of the server, so it would have to be restarted manually in order to see text changes. By including the lang file compilation in the main app start-up we can ensure that the running app in dev mode always shows the most recent content.

This does cause a slight overhead for restarts due to regular code changes, but it is minimal.