### PR TITLE
FLHO-474 Allow museum addresses to be deleted

### DIFF
--- a/apps/museums/controllers/exhibit-address-loop.js
+++ b/apps/museums/controllers/exhibit-address-loop.js
@@ -9,15 +9,4 @@ module.exports = class LocationAddressLoopController extends LoopController {
     return _.mapKeys(super.getLoopFields(req, res), (value, key) => key.replace(/^exhibit\-/, ''));
   }
 
-  locals(req, res) {
-    const locals = super.locals(req, res);
-    const items = locals.items.map((address) => {
-      return {
-        address: address.address
-      };
-    });
-    return Object.assign({}, locals, {
-      items: items
-    });
-  }
 };

--- a/apps/museums/index.js
+++ b/apps/museums/index.js
@@ -20,6 +20,7 @@ const contactAddressLookup = AddressLookup({
 
 module.exports = {
   name: 'museums',
+  params: '/:action?/:id?',
   baseUrl: '/museums',
   steps: {
     '/': {


### PR DESCRIPTION
The address IDs were not being exposed to the client so it could not build the URLs correctly. Also the routing was not configured to recognise the parameters.