### PR TITLE
Disable CSP in the acceptance test runs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -59,7 +59,7 @@ pipeline:
     environment:
       - DOCKER_HOST=tcp://127.0.0.1:2375
     commands:
-      - docker run -e NODE_ENV=ci -d --net host firearms
+      - docker run -e NODE_ENV=ci -e DISABLE_CSP=true -d --net host firearms
       - docker run --rm --net host acceptance
     when:
       event: pull_request
@@ -69,7 +69,7 @@ pipeline:
     environment:
       - DOCKER_HOST=tcp://127.0.0.1:2375
     commands:
-      - docker run -e NODE_ENV=ci -d --net host firearms
+      - docker run -e NODE_ENV=ci -e DISABLE_CSP=true -d --net host firearms
       - docker run --rm --net host acceptance
     when:
       branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
   - npm cache clean
   - docker build --tag travis .
-  - docker run -d --net=host -e NODE_ENV=ci travis
+  - docker run -d --net=host -e NODE_ENV=ci -e DISABLE_CSP=true travis
 
 script:
   - npm test && npm run test:acceptance


### PR DESCRIPTION
Automated tests can't run with CSP enabled so the app that runs for acceptance testing needs to have an envvar that turns it off.