### PR TITLE
Bump versions of acceptance testing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "chai-as-promised": "^6.0.0",
     "eslint-config-homeoffice": "^2.0.0",
     "express": "^4.14.0",
-    "funkie": "0.0.4",
+    "funkie": "0.0.5",
     "funkie-phantom": "0.0.1",
     "istanbul": "^0.4.5",
     "mocha": "^2.2.5",
@@ -66,7 +66,7 @@
     "sinomocha": "^0.2.4",
     "sinon": "^1.15.3",
     "sinon-chai": "^2.8.0",
-    "so-acceptance": "^4.2.0"
+    "so-acceptance": "^4.2.5"
   },
   "pre-commit": [
     "lint",


### PR DESCRIPTION
`funkie` needs an explicit bump because it won't get patch updates at 0.0.x

`so-acceptance` gets an explicit bump because the previous version was fully broken.