### PR TITLE
Remove non-existent fields from step config

### DIFF
--- a/apps/new-dealer/index.js
+++ b/apps/new-dealer/index.js
@@ -187,11 +187,6 @@ module.exports = {
     '/usage': {
       fields: [
         'usage',
-        'sell-details',
-        'transport-details',
-        'transfer-details',
-        'training-details',
-        'research-details',
         'other-details'
       ],
       next: '/ammunition',


### PR DESCRIPTION
The new template mixins means that declaring these fields causes them to be rendered as default, but they don't exist anywhere in field config or translations, and are not dependents of other fields.