### PR TITLE
Add behaviour for submission to iCasework

### DIFF
--- a/apps/common/behaviours/casework-submission.js
+++ b/apps/common/behaviours/casework-submission.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const CaseworkModel = require('../models/i-casework');
+
+const Compose = func => superclass => class extends superclass {
+
+  prepare() {
+    if (typeof func === 'function') {
+      return Object.assign(super.prepare(), func(this.toJSON()));
+    }
+    return super.prepare();
+  }
+
+};
+
+module.exports = config => {
+
+  config = config || {};
+
+  // compose custom per-app prepare methods onto the standard model
+  const Model = Compose(config.prepare)(CaseworkModel);
+
+  return superclass => class extends superclass {
+
+    saveValues(req, res, next) {
+      const model = new Model(req.sessionModel.toJSON());
+      model.save()
+        .then(() => {
+          super.saveValues(req, res, next);
+        }, next);
+    }
+
+  };
+
+};

--- a/apps/common/models/i-casework.js
+++ b/apps/common/models/i-casework.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const Model = require('hof-model');
+const crypto = require('crypto');
+
+const config = require('../../../config').icasework;
+
+module.exports = class CaseworkModel extends Model {
+
+  url() {
+    return config.url;
+  }
+
+  prepare() {
+    return {
+      Key: config.key,
+      Signature: this.sign(),
+      Type: 'Firearms',
+      Format: 'json',
+      db: 'flcms'
+    };
+  }
+
+  sign() {
+    const date = (new Date()).toISOString().split('T')[0];
+    return crypto.createHash('md5').update(date + config.secret).digest('hex');
+  }
+
+  save() {
+    const options = this.requestConfig({});
+    options.qs = this.prepare();
+    options.method = 'POST';
+    return this.request(options);
+  }
+
+};

--- a/config.js
+++ b/config.js
@@ -35,6 +35,11 @@ module.exports = {
     ignoreTLS: process.env.IGNORE_TLS === 'true',
     secure: process.env.EMAIL_SECURE === 'true',
     port: process.env.EMAIL_PORT || '',
-    host: process.env.EMAIL_HOST || '',
+    host: process.env.EMAIL_HOST || ''
+  },
+  icasework: {
+    url: process.env.ICASEWORK_URL || 'https://uat.icasework.com/createcase',
+    key: process.env.ICASEWORK_KEY,
+    secret: process.env.ICASEWORK_SECRET
   }
 };

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "hof-form-controller": "^4.0.0",
     "hof-frontend-toolkit": "^1.1.0",
     "hof-middleware-markdown": "^1.0.0",
-    "hof-model": "^2.1.0",
+    "hof-model": "^3.0.0",
     "hof-transpiler": "^0.2.1",
     "jquery": "^2.1.4",
     "lodash": "^4.17.4",


### PR DESCRIPTION
Provides a behaviour that makes a POST to iCasework's create case API as part of `saveValues`. The behaviour allows for a custom `prepare` method to be passed as part of the behaviour configuration which can extend the default auth attributes with the appropriate case data for each of our applications.

```js
// in steps config
const CaseWorkSubmission = require('../common/behaviours/casework-submission');

'/confirm': {
  behaviours: [
    'complete',
    CaseWorkSubmission({
      prepare: (session) => { /* return data fields */ }
    })
  ],
  next: '/confirmation'
  ...
}
```