### PR TITLE
Fix bug with supporting docs pre-loop step blocking itself

### DIFF
--- a/apps/new-dealer/acceptance/features/_happy-path.js
+++ b/apps/new-dealer/acceptance/features/_happy-path.js
@@ -1,0 +1,37 @@
+'use strict';
+
+// create a function that returns the next item of an array every time it is called
+const iterate = (arr) => {
+  let count = 0;
+  return () => {
+    const value = arr[count];
+    count++;
+    return value || arr[arr.length - 1];
+  };
+};
+
+const values = {
+  activity: 'new',
+  organisation: 'company',
+  'weapons-types': 'fully-automatic',
+  'ammunition-types': 'explosive-cartridges',
+  'first-authority-holders-nationality-multi': null,
+  'contact-holder': 'first',
+  'supporting-document-add-another': iterate(['yes', 'no']),
+  'supporting-document-upload': __filename
+};
+
+Feature('Happy path');
+
+Before((
+  I
+) => {
+  I.amOnPage('/s5/activity');
+});
+
+Scenario('An applicaton can be completed end-to-end', (
+  I
+) => {
+  I.completeToStep('/s5/confirmation', values);
+});
+

--- a/apps/new-dealer/index.js
+++ b/apps/new-dealer/index.js
@@ -284,7 +284,7 @@ module.exports = {
         'first-authority-holders-nationality',
         'first-authority-holders-nationality-multi',
         'first-authority-holders-nationality-second',
-        'first-authority-holders-nationality-third',
+        'first-authority-holders-nationality-third'
       ],
       next: '/first-authority-holders-postcode',
       locals: {
@@ -557,15 +557,29 @@ module.exports = {
         section: 'contacts-details'
       }
     },
+    '/supporting-documents-add': {
+      controller: require('../common/controllers/supporting-documents-add-another'),
+      fields: [
+        'supporting-document-add-another'
+      ],
+      forks: [{
+        target: '/supporting-documents',
+        condition: {
+          field: 'supporting-document-add-another',
+          value: 'yes'
+        }
+      }],
+      next: '/confirm'
+    },
     '/supporting-documents': {
       controller: require('../common/controllers/supporting-documents'),
       fields: [
         'supporting-document-upload',
         'supporting-document-description'
       ],
-      next: '/supporting-documents-add'
+      next: '/supporting-documents-add-another'
     },
-    '/supporting-documents-add': {
+    '/supporting-documents-add-another': {
       controller: require('../common/controllers/supporting-documents-add-another'),
       fields: [
         'supporting-document-add-another'

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "sinomocha": "^0.2.4",
     "sinon": "^1.15.3",
     "sinon-chai": "^2.8.0",
-    "so-acceptance": "^4.2.5"
+    "so-acceptance": "^4.3.0"
   },
   "pre-commit": [
     "lint",


### PR DESCRIPTION
Crude solution is to rename the step so it appears as two different steps rather than the same step in two places.

Adds an end-to-end test that passes through this journey.