### PR TITLE
Unset manual/lookup address fields when completing the other

### DIFF
--- a/apps/common/controllers/address-lookup.js
+++ b/apps/common/controllers/address-lookup.js
@@ -31,6 +31,7 @@ module.exports = class AddressLookup extends BaseController {
     const field = this.options.locals.field;
     req.form.values[`${field}-address-lookup`] = req.form.values[`${field}-address-lookup`].split(', ').join('\n');
     req.sessionModel.unset('addresses');
+    req.sessionModel.unset(`${field}-address-manual`);
     super.saveValues(req, res, callback);
   }
 

--- a/apps/common/controllers/address.js
+++ b/apps/common/controllers/address.js
@@ -23,4 +23,11 @@ module.exports = class AddressController extends BaseController {
       postcodeApiMessageKey: isManual ? '' : (req.sessionModel.get('postcodeApiMeta') || {}).messageKey
     });
   }
+
+  saveValues(req, res, callback) {
+    const field = this.options.locals.field;
+    req.sessionModel.unset(`${field}-address-lookup`);
+    super.saveValues(req, res, callback);
+  }
+
 };

--- a/apps/new-dealer/controllers/confirm.js
+++ b/apps/new-dealer/controllers/confirm.js
@@ -119,7 +119,8 @@ module.exports = class ConfirmController extends controllers {
   addContactDetailsSection(data, translate, result) {
     const contactHolder = data['contact-holder'];
     const contactName = this.getContactHoldersName(data);
-    const contactAddress = data[`${contactHolder}-authority-holders-address-manual`];
+    const key = `${contactHolder}-authority-holders-address`;
+    const contactAddress = data[`${key}-manual`] || data[`${key}-lookup`];
     return result.map(section => {
       if (section.fields !== undefined) {
         section.fields = section.fields.map(field => {
@@ -128,9 +129,13 @@ module.exports = class ConfirmController extends controllers {
           } else if (field.field === 'use-different-address') {
             field.label = translate('fields.authority-holder-contact-address-manual.summary');
             field.value = contactAddress;
+          } else if (field.field.match(/^contact-address-(lookup|manual)$/)) {
+            if (data['use-different-address'] === 'false') {
+              return;
+            }
           }
           return field;
-        });
+        }).filter(a => a);
       }
       return section;
     });


### PR DESCRIPTION
If a user goes through an address journey more than once, following manual entry *and* a successful lookup on different occasions then they end up with both fields populated on the confirm page, and two addresses will appear.

Instead unset the other address field whenever either a manual address or a lookup is completed.