### PR TITLE
Unset multiple addresses

### DIFF
--- a/apps/common/controllers/address-lookup.js
+++ b/apps/common/controllers/address-lookup.js
@@ -31,6 +31,7 @@ module.exports = class AddressLookup extends BaseController {
     const field = this.options.locals.field;
     req.form.values[`${field}-address-lookup`] = req.form.values[`${field}-address-lookup`].split(', ').join('\n');
     req.sessionModel.unset('addresses');
+    req.sessionModel.unset(`${field}-address-manual`);
     super.saveValues(req, res, callback);
   }
 

--- a/apps/common/controllers/address.js
+++ b/apps/common/controllers/address.js
@@ -23,4 +23,11 @@ module.exports = class AddressController extends BaseController {
       postcodeApiMessageKey: isManual ? '' : (req.sessionModel.get('postcodeApiMeta') || {}).messageKey
     });
   }
+
+  saveValues(req, res, callback) {
+    const field = this.options.locals.field;
+    req.sessionModel.unset(`${field}-address-lookup`);
+    super.saveValues(req, res, callback);
+  }
+
 };

--- a/apps/new-dealer/controllers/confirm.js
+++ b/apps/new-dealer/controllers/confirm.js
@@ -119,7 +119,8 @@ module.exports = class ConfirmController extends controllers {
   addContactDetailsSection(data, translate, result) {
     const contactHolder = data['contact-holder'];
     const contactName = this.getContactHoldersName(data);
-    const contactAddress = data[`${contactHolder}-authority-holders-address-manual`];
+    const key = `${contactHolder}-authority-holders-address`;
+    const contactAddress = data[`${key}-manual`] || data[`${key}-lookup`];
     return result.map(section => {
       if (section.fields !== undefined) {
         section.fields = section.fields.map(field => {
@@ -128,9 +129,13 @@ module.exports = class ConfirmController extends controllers {
           } else if (field.field === 'use-different-address') {
             field.label = translate('fields.authority-holder-contact-address-manual.summary');
             field.value = contactAddress;
+          } else if (field.field.match(/^contact-address-(lookup|manual)$/)) {
+            if (data['use-different-address'] === 'false') {
+              return;
+            }
           }
           return field;
-        });
+        }).filter(a => a);
       }
       return section;
     });

--- a/apps/new-dealer/controllers/confirm.js
+++ b/apps/new-dealer/controllers/confirm.js
@@ -129,13 +129,9 @@ module.exports = class ConfirmController extends controllers {
           } else if (field.field === 'use-different-address') {
             field.label = translate('fields.authority-holder-contact-address-manual.summary');
             field.value = contactAddress;
-          } else if (field.field.match(/^contact-address-(lookup|manual)$/)) {
-            if (data['use-different-address'] === 'false') {
-              return;
-            }
           }
           return field;
-        }).filter(a => a);
+        });
       }
       return section;
     });

--- a/apps/new-dealer/fields/index.js
+++ b/apps/new-dealer/fields/index.js
@@ -591,7 +591,14 @@ module.exports = {
     legend: {
       className: 'visuallyhidden'
     },
-    options: ['first', 'second', {value: 'other', toggle: 'someone-else-name', child: 'input-text'}]
+    options: ['first', 'second', {value: 'other', toggle: 'someone-else-name', child: 'input-text'}],
+    invalidates: [
+      'contact-address-lookup',
+      'contact-address-manual',
+      'authority-holder-contact-postcode',
+      'authority-holder-contact-address-lookup',
+      'authority-holder-contact-address-manual'
+    ]
   },
   'someone-else-name': {
     validate: 'required',
@@ -640,7 +647,12 @@ module.exports = {
       value: 'true',
       toggle: 'authority-holder-contact-postcode',
       child: 'partials/postcode-manual-link'
-    }]
+    }],
+    invalidates: [
+      'authority-holder-contact-postcode',
+      'authority-holder-contact-address-lookup',
+      'authority-holder-contact-address-manual'
+    ]
   },
   'authority-holder-contact-postcode': {
     validate: ['required', 'postcode'],


### PR DESCRIPTION
If the user goes along multiple different forking paths in the same application then they end up with multiple addresses on their model, which end up being displayed multiple times.

Instead, if a user enters an address or fills a field in one place that makes a previous entry redundant then unset the old value.

