### PR TITLE
Fix timezone settings in live environments

### DIFF
--- a/apps/common/behaviours/emailer.js
+++ b/apps/common/behaviours/emailer.js
@@ -3,7 +3,7 @@
 const path = require('path');
 const emailer = require('hof-behaviour-emailer');
 const config = require('../../../config');
-const moment = require('moment');
+const moment = require('moment-timezone');
 
 module.exports = conf => {
   const defaults = {
@@ -14,7 +14,7 @@ module.exports = conf => {
         reference: data.caseid,
         type: conf.type,
         name: data[nameKey],
-        date: moment().format('LLL')
+        date: moment().tz('Europe/London').format('LLL')
       };
     }
   };

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "jquery": "^2.1.4",
     "lodash": "^4.17.4",
     "moment": "^2.18.1",
+    "moment-timezone": "^0.5.11",
     "mustache": "^2.3.0",
     "npm-sass": "^2.0.0",
     "phantomjs-prebuilt": "^2.1.14",


### PR DESCRIPTION
Ensure that the timezone of the dates sent in outbound emails is in the UK timezone, irrespective of the timezone settings on the server itself.