### PR TITLE
Override default error template

### DIFF
--- a/apps/common/views/error.html
+++ b/apps/common/views/error.html
@@ -1,0 +1,14 @@
+{{<layout}}
+  {{$header}}
+    {{content.title}}
+  {{/header}}
+  {{$content}}
+    <p>{{{content.message}}}</p>
+    <a href="/{{startLink}}" class="button" role="button">{{#t}}buttons.start-again{{/t}}</a>
+    {{#showStack}}
+      <pre>
+        {{error.stack}}
+      </pre>
+    {{/showStack}}
+  {{/content}}
+{{/layout}}


### PR DESCRIPTION
Default template doesn't correctly use the startLink which is set by the error handler middleware so always redirects to root, which 404s dumping the user in a broken place.