### PR TITLE
Update docker file to use run.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,6 @@ RUN npm --loglevel warn install --production
 COPY . /app
 RUN npm --loglevel warn run postinstall --production
 
-RUN cp -r /app/public/* /public/ && \
-    chown -R nodejs:nodejs /public
-
 USER nodejs
 
-ENTRYPOINT ["node"]
-
-CMD ["/app/app.js"]
+CMD ["/app/run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# kubernetes does not support volumes-from so when we want to
+# share a dir with nginx we use /public which is an emptyDir
+# we then copy files from app/public on start of the container which
+# is why this line exists until kube has a better method of
+# sharing directiries between containers
+cp -r /app/public/* /public/
+
+node app.js


### PR DESCRIPTION
Added lots of comments about this.

We use run.sh for kubernetes and it's volume mounting.

/public starts as an empty dir so we copy the contents of /app/public

into /public for nginx to serve.