### PR TITLE
Use the same nginx proxy docker images as prod

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,16 +23,17 @@ services:
     image: redis
 
   nginx-proxy:
-    image: quay.io/ukhomeofficedigital/nginx-proxy:v1.5.1
+    image: quay.io/ukhomeofficedigital/nginx-proxy-govuk:v3.0.0.0
     environment:
       - PROXY_SERVICE_HOST=app
       - PROXY_SERVICE_PORT=8080
       - NAXSI_USE_DEFAULT_RULES=FALSE
+      - CLIENT_MAX_BODY_SIZE=200
       - ADD_NGINX_SERVER_CFG=add_header Cache-Control private;add_header X-Frame-Options "SAMEORIGIN" always;add_header X-Content-Type-Options "nosniff" always;add_header X-XSS-Protection "1; mode=block" always;location /public {add_header Cache-Control max-age=86400;add_header X-Frame-Options "SAMEORIGIN" always;add_header X-Content-Type-Options "nosniff" always;add_header X-XSS-Protection "1; mode=block" always;alias /public;}
       - ERROR_REDIRECT_CODES=599
     ports:
-      - "443:443"
-      - "80:80"
+      - "443:10443"
+      - "80:10080"
     links:
       - app
     volumes_from:


### PR DESCRIPTION
Set the nginx proxy versions for local development to be as per https://github.com/UKHomeOffice/kube-firearms/blob/master/kube/app-deployment.yml

