### PR TITLE
Clear contact details when changing nominated contact

### DIFF
--- a/apps/new-dealer/fields/index.js
+++ b/apps/new-dealer/fields/index.js
@@ -593,6 +593,8 @@ module.exports = {
     },
     options: ['first', 'second', {value: 'other', toggle: 'someone-else-name', child: 'input-text'}],
     invalidates: [
+      'contact-email',
+      'contact-phone',
       'contact-address-lookup',
       'contact-address-manual',
       'authority-holder-contact-postcode',


### PR DESCRIPTION
When changing the nominated contact from 1st auth holder to 2nd auth holder (for example) then clear any pre-entered contact details that might exist.

https://jira.digital.homeoffice.gov.uk/browse/FLHO-261