### PR TITLE
Fix error thrown on S5 confirm page if no supporting docs

### DIFF
--- a/apps/new-dealer/controllers/confirm.js
+++ b/apps/new-dealer/controllers/confirm.js
@@ -131,6 +131,9 @@ module.exports = class ConfirmController extends Controller {
   }
 
   getSupportingDocuments(data, translate) {
+    if (!data['supporting-documents'] || !data['supporting-documents']) {
+      return null;
+    }
     const items = data['supporting-documents'].map(doc => ({
       fields: {
         field: 'supporting-documents',


### PR DESCRIPTION
If no documents are uploaded then `data['supporting-docs']` doesn't exist and so `map`-ing it fails.