### PR TITLE
Allow address lookups to complete when editing

### DIFF
--- a/apps/common/controllers/address/postcode.js
+++ b/apps/common/controllers/address/postcode.js
@@ -21,6 +21,7 @@ module.exports = class PostcodeController extends AddressController {
     }, req.form.options.fieldSettings);
 
     // add conditonal fork
+    req.form.options.continueOnEdit = true;
     req.form.options.forks = req.form.options.forks || [];
     req.form.options.forks.push({
       target: req.form.options.select,


### PR DESCRIPTION
Previously the address lookup skipped back to the confirm answers page when submitting a postcode

https://jira.digital.homeoffice.gov.uk/browse/FLHO-500