### PR TITLE
Make the max file upload size 100mb

### DIFF
--- a/config.js
+++ b/config.js
@@ -17,7 +17,7 @@ module.exports = {
     }
   },
   upload: {
-    maxfilesize: '200mb',
+    maxfilesize: '100mb',
     hostname: env !== 'production' ?
       `http://${localhost()}/api/file-upload` :
       process.env.FILE_VAULT_URL


### PR DESCRIPTION
This will set the max file upload size to 100mb in the app. It does not restrict the file size permitted by Nginx.