### PR TITLE
Remove typeahead functionality from import field

### DIFF
--- a/apps/new-dealer/fields/index.js
+++ b/apps/new-dealer/fields/index.js
@@ -148,15 +148,13 @@ module.exports = {
     options: [{
       value: 'yes',
       toggle: 'import-country',
-      child: 'select'
+      child: 'input-text'
     }, {
       value: 'no'
     }]
   },
   'import-country': {
     validate: 'required',
-    className: ['typeahead', 'js-hidden'],
-    options: [''].concat(require('../../../assets/countries').nonUKcountries),
     dependent: {
       field: 'import',
       value: 'yes'


### PR DESCRIPTION
The user needs to be able to fill in more than one country of origin, or be able to provide other free-form notes.