### PR TITLE
Add existing authority details to S5 summary page

### DIFF
--- a/apps/new-dealer/index.js
+++ b/apps/new-dealer/index.js
@@ -50,7 +50,10 @@ module.exports = {
         'reference-number',
         'authority-number'
       ],
-      next: '/company-name'
+      next: '/company-name',
+      locals: {
+        section: 'business-details'
+      }
     },
     '/company-name': {
       fields: [


### PR DESCRIPTION
These will now appear in the business details section.