### PR TITLE
s5-Change authority holder's contact address to show contact address …

### DIFF
--- a/apps/new-dealer/translations/src/en/fields.json
+++ b/apps/new-dealer/translations/src/en/fields.json
@@ -437,11 +437,11 @@
     "label": "Postcode"
   },
   "authority-holder-contact-address-lookup": {
-    "summary": "Home address",
+    "summary": "Contact address",
     "label": "Select your address"
   },
   "authority-holder-contact-address-manual": {
-    "summary": "Home address",
+    "summary": "Contact address",
     "label": "Address"
   },
   "contact-postcode": {


### PR DESCRIPTION
…in the confirm page rather than home address

Couldn't recreate the other issue, 'the label also appearing twice when only one address has been entered'.  I assume this has been fixed.

https://jira.digital.homeoffice.gov.uk/browse/FLHO-408