### PR TITLE
Updated logic for contact details in the confirm page

### DIFF
--- a/apps/new-dealer/fields/index.js
+++ b/apps/new-dealer/fields/index.js
@@ -591,6 +591,7 @@ module.exports = {
     },
     options: ['first', 'second', {value: 'other', toggle: 'someone-else-name', child: 'input-text'}],
     invalidates: [
+      'use-different-address',
       'contact-email',
       'contact-phone',
       'contact-address-lookup',
@@ -652,7 +653,8 @@ module.exports = {
       'authority-holder-contact-postcode',
       'authority-holder-contact-address-lookup',
       'authority-holder-contact-address-manual'
-    ]
+    ],
+    includeInSummary: false
   },
   'authority-holder-contact-postcode': {
     validate: ['required', 'postcode'],
@@ -675,7 +677,8 @@ module.exports = {
     attributes: [{
       attribute: 'rows',
       value: 5
-    }]
+    }],
+    includeInSummary: false
   },
   'contact-postcode': {
     mixin: 'input-text-code',
@@ -685,7 +688,8 @@ module.exports = {
   },
   'contact-address-lookup': {
     validate: 'required',
-    className: 'address'
+    className: 'address',
+    includeInSummary: false
   },
   'contact-address-manual': {
     mixin: 'textarea',
@@ -695,7 +699,8 @@ module.exports = {
     attributes: [{
       attribute: 'rows',
       value: 5
-    }]
+    }],
+    includeInSummary: false
   },
   'storage-add-another-address': {
     mixin: 'radio-group',

--- a/apps/new-dealer/index.js
+++ b/apps/new-dealer/index.js
@@ -465,7 +465,8 @@ module.exports = {
         renew: true,
         section: 'contacts-details',
         step: 'contact'
-      }
+      },
+      continueOnEdit: true
     },
     '/contact-details': {
       fields: [

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "hof-bootstrap": "^10.3.0",
     "hof-build": "^1.3.1",
     "hof-confirm-controller": "^1.0.2",
-    "hof-controllers": "^6.0.2",
+    "hof-controllers": "^6.0.3",
     "hof-form-controller": "^4.1.0",
     "hof-frontend-toolkit": "^1.1.0",
     "hof-middleware-markdown": "^1.0.0",


### PR DESCRIPTION
This is really @easternbloc PR, details below:
This now takes into account the 8 possible address values that could be available

2 for each possible named person (manual,lookup) = 4
2 for authority-holder-contact-address (manual,lookup) = 2
2 for contact-address (Someone Else) (manual,lookup) = 2

Previous to this we were overwriting use-different-address in the confirm which was nasty so now we just add a new field to the section which we populate with the correct address data.

Updated hof-controllers to accommodate a bug in the confirm page for the edit link