### PR TITLE
Handle icasework failing with 200

### DIFF
--- a/apps/common/behaviours/casework-submission.js
+++ b/apps/common/behaviours/casework-submission.js
@@ -32,7 +32,8 @@ module.exports = config => {
           .then(data => {
             req.sessionModel.set('caseid', data.createcaseresponse.caseid);
             next();
-          }, next);
+          })
+          .catch(next);
       });
     }
 


### PR DESCRIPTION
In some circumstances icasework submission fails, but returns a 200 with an empty response. In these cases the line which accesses `data.createcaseresponse.caseid` fails because the JSON response is empty. By moving the call to next into a catch rather than a second argument we can ensure that these errors are caught and the request pipeline is not broken.