### PR TITLE
Storage address intro

### DIFF
--- a/apps/common/controllers/address-lookup-loop.js
+++ b/apps/common/controllers/address-lookup-loop.js
@@ -29,6 +29,12 @@ module.exports = class AddressLookupLoopController extends BaseAddressController
     callback();
   }
 
+  locals(req, res) {
+    const locals = super.locals(req, res);
+    locals.postcode = req.form.values[`${this.options.locals.field}-postcode`];
+    return locals;
+  }
+
   saveValues(req, res, callback) {
     const address = req.form.values[`${this.options.locals.field}-address-lookup`].split(', ').join('\n');
     let postcode;

--- a/apps/new-dealer/index.js
+++ b/apps/new-dealer/index.js
@@ -127,7 +127,7 @@ module.exports = {
     },
     '/storage-postcode': {
       addressKey: 'storageAddresses',
-      template: 'postcode-loop.html',
+      template: 'storage-address',
       controller: require('../common/controllers/postcode'),
       fields: [
         'storage-postcode'
@@ -151,7 +151,7 @@ module.exports = {
     },
     '/storage-address-lookup': {
       addressKey: 'storageAddresses',
-      template: 'address-lookup-loop.html',
+      template: 'storage-address-lookup',
       controller: require('../common/controllers/address-lookup-loop'),
       fields: [
         'storage-address-lookup'
@@ -166,7 +166,7 @@ module.exports = {
     },
     '/storage-address': {
       addressKey: 'storageAddresses',
-      template: 'address-loop.html',
+      template: 'storage-address-manual',
       controller: require('../common/controllers/address-loop'),
       fields: [
         'storage-address-manual'

--- a/apps/new-dealer/translations/src/en/pages.json
+++ b/apps/new-dealer/translations/src/en/pages.json
@@ -95,17 +95,14 @@
   },
   "storage-postcode": {
     "header": "Where will the prohibited items be stored?",
-    "intro": "You can add further addresses later, if required. The police will inspect the storage arrangements at each location.",
     "important": "The information you provide here will replace the information we currently hold."
   },
   "storage-address-lookup": {
     "header": "Where will the prohibited items be stored?",
-    "intro": "You can add further addresses later, if required. The police will inspect the storage arrangements at each location.",
     "important": "The information you provide here will replace the information we currently hold."
   },
   "storage-address": {
     "header": "Where will the prohibited items be stored?",
-    "intro": "You can add further addresses later, if required. The police will inspect the storage arrangements at each location.",
     "important": "The information you provide here will replace the information we currently hold.",
     "summary": "Storage addresses"
   },

--- a/apps/new-dealer/views/content/storage-addresses.md
+++ b/apps/new-dealer/views/content/storage-addresses.md
@@ -1,0 +1,3 @@
+You can add further addresses later, if required. The police will inspect the storage arrangements at each location.
+
+If any of the items will be stored in Scotland, you'll also need to apply for a separate licence from the Scottish Government.

--- a/apps/new-dealer/views/storage-address-lookup.html
+++ b/apps/new-dealer/views/storage-address-lookup.html
@@ -1,0 +1,5 @@
+{{<address-lookup-loop}}
+  {{$intro}}
+    {{#markdown}}storage-addresses{{/markdown}}
+  {{/intro}}
+{{/address-lookup-loop}}

--- a/apps/new-dealer/views/storage-address-manual.html
+++ b/apps/new-dealer/views/storage-address-manual.html
@@ -1,0 +1,5 @@
+{{<address-loop}}
+  {{$intro}}
+    {{#markdown}}storage-addresses{{/markdown}}
+  {{/intro}}
+{{/address-loop}}

--- a/apps/new-dealer/views/storage-address.html
+++ b/apps/new-dealer/views/storage-address.html
@@ -1,0 +1,5 @@
+{{<postcode-loop}}
+  {{$intro}}
+    {{#markdown}}storage-addresses{{/markdown}}
+  {{/intro}}
+{{/postcode-loop}}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "hof-frontend-toolkit": "^2.1.0",
     "hof-middleware-markdown": "^1.0.0",
     "hof-model": "^3.0.1",
+    "hof-theme-govuk": "^2.0.3",
     "html-pdf": "^2.1.0",
     "i18n-lookup": "^1.0.0",
     "jquery": "^2.1.4",
@@ -64,7 +65,7 @@
     "sinomocha": "^0.2.4",
     "sinon": "^1.15.3",
     "sinon-chai": "^2.9.0",
-    "so-acceptance": "^4.3.0"
+    "so-acceptance": "^4.3.1"
   },
   "pre-commit": [
     "lint",


### PR DESCRIPTION
Adds an extra paragraph to the intro section on storage address pages.

This needed a bit of a template dance because the intro was stuck to being a single string, and couldn't handle the extra paragraph easily.

See https://github.com/UKHomeOfficeForms/hof-template-partials/pull/25