### PR TITLE
Remove markdown middleware

### DIFF
--- a/app.js
+++ b/app.js
@@ -31,5 +31,5 @@ if (config.env === 'ci' || config.env === 'development') {
   app.use(mockAPIs);
 }
 app.use(bodyParser({limit: config.upload.maxfilesize}));
-app.use(require('hof-middleware-markdown')());
+
 app.start();

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "hof-controllers": "^6.0.3",
     "hof-form-controller": "^4.1.0",
     "hof-frontend-toolkit": "^2.1.0",
-    "hof-middleware-markdown": "^1.0.0",
     "hof-model": "^3.0.1",
     "html-pdf": "^2.1.0",
     "i18n-lookup": "^1.0.0",


### PR DESCRIPTION
It is now included in bootstrap so there's no need to include it here as well.