### PR TITLE
Supporting document add error message

### DIFF
--- a/apps/new-dealer/translations/src/en/validation.json
+++ b/apps/new-dealer/translations/src/en/validation.json
@@ -245,5 +245,8 @@
   },
   "contact-address-lookup": {
     "required": "Select an address"
+  },
+  "supporting-document-add": {
+    "required": "Select an option to upload supporting documents now or later"
   }
 }


### PR DESCRIPTION
Add an error message for `required` validation on the supporting document add page