### PR TITLE
Add debugging information to casework submission

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const bootstrap = require('hof-bootstrap');
+const hof = require('hof');
 const bodyParser = require('busboy-body-parser');
 const config = require('./config.js');
 const mockAPIs = require('./mock-apis.js');
@@ -26,7 +26,7 @@ const options = {
   redis: config.redis
 };
 
-const app = bootstrap(options);
+const app = hof(options);
 if (config.env === 'ci' || config.env === 'development') {
   app.use(mockAPIs);
 }

--- a/apps/common/behaviours/casework-submission.js
+++ b/apps/common/behaviours/casework-submission.js
@@ -23,6 +23,7 @@ module.exports = config => {
   return superclass => class extends superclass {
 
     saveValues(req, res, next) {
+      req.log('debug', 'Submitting case to icasework');
       super.saveValues(req, res, err => {
         if (err) {
           return next(err);
@@ -30,10 +31,15 @@ module.exports = config => {
         const model = new Model(req.sessionModel.toJSON());
         model.save()
           .then(data => {
+            req.log('debug', `Successfully submitted case to icasework (${data.createcaseresponse.caseid})`);
             req.sessionModel.set('caseid', data.createcaseresponse.caseid);
             next();
           })
-          .catch(next);
+          .catch(e => {
+            req.log('error', `Casework submission failed: ${e.status}`);
+            req.log('error', e.body);
+            next(e);
+          });
       });
     }
 

--- a/apps/common/controllers/postcode.js
+++ b/apps/common/controllers/postcode.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const _ = require('lodash');
-const logger = require('hof-bootstrap/lib/logger');
 const BaseController = require('./base');
 const PostcodesModel = require('../models/postcodes');
 const path = require('path');
@@ -46,7 +45,7 @@ module.exports = class PostcodeController extends BaseController {
         req.sessionModel.set('postcodeApiMeta', {
           messageKey: 'cant-connect'
         });
-        logger.error('Postcode lookup error: ',
+        req.log('error', 'Postcode lookup error: ',
           `Code: ${err.status}; Detail: ${err.detail}`);
         return callback();
       });

--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
   },
   "dependencies": {
     "busboy-body-parser": "^0.3.0",
-    "express": "^4.14.1",
+    "express": "^4.15.3",
+    "hof": "^12.0.4",
     "hof-behaviour-emailer": "^2.0.0",
-    "hof-bootstrap": "^11.2.0",
-    "hof-build": "^1.3.1",
+    "hof-build": "^1.3.3",
     "hof-confirm-controller": "^1.0.2",
     "hof-controllers": "^6.0.3",
     "hof-form-controller": "^4.1.0",
-    "hof-model": "^3.0.1",
+    "hof-model": "^3.1.0",
     "hof-theme-govuk": "^2.0.3",
     "hof-util-countries": "^1.0.0",
     "html-pdf": "^2.1.0",
@@ -45,13 +45,12 @@
     "phantomjs-prebuilt": "^2.1.14",
     "typeahead-aria": "^1.0.4",
     "uuid": "^3.0.1",
-    "witch": "^1.0.1"
+    "witch": "^1.0.2"
   },
   "devDependencies": {
     "chai": "^3.0.0",
     "chai-as-promised": "^6.0.0",
     "eslint-config-homeoffice": "^2.0.0",
-    "express": "^4.14.0",
     "funkie": "0.0.5",
     "funkie-phantom": "0.0.1",
     "istanbul": "^0.4.5",


### PR DESCRIPTION
This will hopefully allow us to get some more information about why casework submission might be failing in certain circumstances.

Module version updates courtesy of npm@5's auto `--save`, but no harm in updating things.