### PR TITLE
Integrate the supporting docs app with icasework APIs

### DIFF
--- a/apps/common/behaviours/casework-submission.js
+++ b/apps/common/behaviours/casework-submission.js
@@ -17,8 +17,11 @@ module.exports = config => {
 
   config = config || {};
 
+  // allow a custom model override
+  config.Model = config.Model || CaseworkModel;
+
   // compose custom per-app prepare methods onto the standard model
-  const Model = Compose(config.prepare)(CaseworkModel);
+  const Model = Compose(config.prepare)(config.Model);
 
   return superclass => class extends superclass {
 
@@ -29,6 +32,7 @@ module.exports = config => {
           return next(err);
         }
         const model = new Model(req.sessionModel.toJSON());
+        req.log('debug', `Sending icasework submission to ${model.url()}`);
         model.save()
           .then(data => {
             req.log('debug', `Successfully submitted case to icasework (${data.createcaseresponse.caseid})`);

--- a/apps/common/models/i-casework-documents.js
+++ b/apps/common/models/i-casework-documents.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const Model = require('./i-casework');
+const crypto = require('crypto');
+
+const config = require('../../../config');
+
+module.exports = class DocumentModel extends Model {
+
+  url() {
+    return config.icasework.url + config.icasework.uploadpath;
+  }
+
+  sign() {
+    const date = (new Date()).toISOString().split('T')[0];
+    return crypto.createHash('md5').update(this.get('reference-number') + date + config.icasework.secret).digest('hex');
+  }
+
+  parse(data) {
+    return {
+      createcaseresponse: data.uploaddocumentsresponse
+    };
+  }
+
+};

--- a/apps/common/models/i-casework-getcase.js
+++ b/apps/common/models/i-casework-getcase.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const Model = require('./i-casework');
+const crypto = require('crypto');
+
+const config = require('../../../config');
+
+module.exports = class DocumentModel extends Model {
+
+  url() {
+    return config.icasework.url + config.icasework.getcasepath;
+  }
+
+  sign() {
+    const date = (new Date()).toISOString().split('T')[0];
+    return crypto.createHash('md5').update(this.get('reference-number') + date + config.icasework.secret).digest('hex');
+  }
+
+  prepare(data) {
+    const props = super.prepare(data);
+    props.CaseId = this.get('reference-number');
+    return props;
+  }
+
+  parse(data) {
+    return {
+      name: data['MainParty.FullName'],
+      email: data['MainParty.EmailAddress']
+    };
+  }
+
+  fetch() {
+    const options = this.requestConfig({});
+    options.qs = this.prepare();
+    options.method = 'GET';
+    return this.request(options);
+  }
+
+};

--- a/apps/common/models/i-casework.js
+++ b/apps/common/models/i-casework.js
@@ -8,7 +8,7 @@ const config = require('../../../config');
 module.exports = class CaseworkModel extends Model {
 
   url() {
-    return config.icasework.url;
+    return config.icasework.url + config.icasework.createpath;
   }
 
   prepare() {

--- a/apps/supporting-documents/behaviours/check-email.js
+++ b/apps/supporting-documents/behaviours/check-email.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = superclass => class extends superclass {
+
+  validate(req, res, next) {
+    if (req.sessionModel.get('original-email') !== req.form.values.email) {
+      next({
+        email: new this.ValidationError('email', { type: 'incorrect' })
+      });
+    } else {
+      super.validate(req, res, next);
+    }
+  }
+
+};

--- a/apps/supporting-documents/behaviours/get-case.js
+++ b/apps/supporting-documents/behaviours/get-case.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const Model = require('../../common/models/i-casework-getcase');
+
+module.exports = superclass => class extends superclass {
+
+  saveValues(req, res, next) {
+    const model = new Model(req.form.values);
+    model.fetch()
+      .catch(() => {
+        return {};
+      })
+      .then(data => {
+        req.sessionModel.set('original-email', data.email);
+        req.sessionModel.set('original-name', data.name);
+        super.saveValues(req, res, next);
+      });
+  }
+
+};

--- a/apps/supporting-documents/emails/confirm.html
+++ b/apps/supporting-documents/emails/confirm.html
@@ -1,0 +1,17 @@
+<p>Dear {{name}},</p>
+
+<p>We have received the additional supporting documents for application reference <strong>{{reference}}</strong>.</p>
+
+<p>The firearms licensing unit will consider your application and contact you at this email address if any further information is required, or when your application has been approved or rejected.</p>
+
+<p>If you have any queries, or believe you have received this email in error, contact the firearms licensing unit:</p>
+
+<p><a href="mailto:firearms.applications@homeoffice.gsi.gov.uk">firearms.applications@homeoffice.gsi.gov.uk</a></p>
+
+<p>020 7035 3538</p>
+
+<p>Firearms licensing unit<br/>
+5th Floor, Fry Building<br/>
+2 Marsham Street<br/>
+London<br/>
+SW1P 4DF</p>

--- a/apps/supporting-documents/fields/index.js
+++ b/apps/supporting-documents/fields/index.js
@@ -1,3 +1,10 @@
 'use strict';
 
-module.exports = {};
+module.exports = {
+  'email': {
+    validate: [
+      'required',
+      'email'
+    ]
+  }
+};

--- a/apps/supporting-documents/index.js
+++ b/apps/supporting-documents/index.js
@@ -1,5 +1,12 @@
 'use strict';
 
+const Submission = require('../common/behaviours/casework-submission');
+const submission = Submission({
+  prepare: require('./models/submission'),
+  Model: require('../common/models/i-casework-documents')
+});
+
+
 module.exports = {
   name: 'supporting-documents',
   baseUrl: '/supporting-documents',
@@ -54,7 +61,7 @@ module.exports = {
     },
     '/declaration': {
       template: 'declaration',
-      behaviours: ['complete'],
+      behaviours: ['complete', submission],
       next: '/confirmation'
     },
     '/confirmation': {

--- a/apps/supporting-documents/models/submission.js
+++ b/apps/supporting-documents/models/submission.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = data => {
+  const response = {};
+
+  response.CaseId = data['reference-number'];
+
+  const docs = data['supporting-documents'] || [];
+
+  docs.forEach((doc, i) => {
+    response[`Document${i + 1}.URL`] = doc.url;
+    response[`Document${i + 1}.Name`] = doc.description;
+    response[`Document${i + 1}.MimeType`] = doc.type;
+    response[`Document${i + 1}.URLLoadContent`] = true;
+  });
+
+  return response;
+};

--- a/apps/supporting-documents/translations/src/en/fields.json
+++ b/apps/supporting-documents/translations/src/en/fields.json
@@ -1,5 +1,8 @@
 {
   "reference-number": {
     "label": "Reference number"
+  },
+  "email": {
+    "label": "Email"
   }
 }

--- a/apps/supporting-documents/translations/src/en/pages.json
+++ b/apps/supporting-documents/translations/src/en/pages.json
@@ -2,6 +2,9 @@
   "reference": {
     "header": "What is the reference number for your application?"
   },
+  "email": {
+    "header": "What is the email address used for your original application?"
+  },
   "supporting-documents": {
     "header": "Supporting documents"
   },

--- a/apps/supporting-documents/translations/src/en/validation.json
+++ b/apps/supporting-documents/translations/src/en/validation.json
@@ -2,6 +2,10 @@
   "reference-number": {
     "required": "Enter your application reference number"
   },
+  "email": {
+    "required": "Enter the email address used for your original application",
+    "incorrect": "The email address provided does not match the reference number"
+  },
   "supporting-document-upload": {
     "required": "Select a document"
   }

--- a/config.js
+++ b/config.js
@@ -44,6 +44,7 @@ module.exports = {
     url: process.env.ICASEWORK_URL || 'https://uat.icasework.com',
     createpath: '/createcase',
     uploadpath: '/uploaddocuments',
+    getcasepath: '/getcasedetails',
     key: process.env.ICASEWORK_KEY,
     secret: process.env.ICASEWORK_SECRET
   },

--- a/config.js
+++ b/config.js
@@ -41,7 +41,9 @@ module.exports = {
     password: process.env.REDIS_PASSWORD
   },
   icasework: {
-    url: process.env.ICASEWORK_URL || 'https://uat.icasework.com/createcase',
+    url: process.env.ICASEWORK_URL || 'https://uat.icasework.com',
+    createpath: '/createcase',
+    uploadpath: '/uploaddocuments',
     key: process.env.ICASEWORK_KEY,
     secret: process.env.ICASEWORK_SECRET
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "hof-build": "^1.3.3",
     "hof-confirm-controller": "^1.0.2",
     "hof-controllers": "^6.0.3",
-    "hof-form-controller": "^4.1.0",
+    "hof-form-controller": "^5.0.0",
     "hof-model": "^3.1.0",
     "hof-theme-govuk": "^2.0.3",
     "hof-util-countries": "^1.0.0",


### PR DESCRIPTION
* Adds an email step to collect the email address associated with the original application.
* Performs a lookup of the case data from icasework to validate the email address
* Adds the documents to the case in icasework
* Sends an email to the original email address if successful

Note: this will need a config change on kube-firearms to update the icasework url to remove the path.