### PR TITLE
Unset email when amending reference number

### DIFF
--- a/apps/supporting-documents/fields/index.js
+++ b/apps/supporting-documents/fields/index.js
@@ -1,6 +1,10 @@
 'use strict';
 
 module.exports = {
+  'reference-number': {
+    validate: ['required'],
+    invalidates: ['email']
+  },
   'email': {
     validate: [
       'required',

--- a/apps/supporting-documents/index.js
+++ b/apps/supporting-documents/index.js
@@ -67,7 +67,7 @@ module.exports = {
       controller: require('hof-confirm-controller'),
       next: '/declaration',
       sections: {
-        reference: ['reference-number'],
+        reference: ['reference-number', 'email'],
         documents: [
           {
             field: 'supporting-documents',


### PR DESCRIPTION
In supporting documents app, if a user goes back from the check answers page and edits the reference number then the original email should be re-entered to check it corresponds to that associated with the original application.