### PR TITLE
Improve layout of pdf documents

### DIFF
--- a/apps/common/views/pdf.html
+++ b/apps/common/views/pdf.html
@@ -14,6 +14,23 @@
       html {
         background: white;
       }
+
+      table {
+        width: 100%;
+      }
+      table td:nth-child(1) {
+        width: 33%;
+      }
+      table td:nth-child(2) {
+        white-space: pre;
+      }
+      table td:nth-child(3) {
+        display: none;
+      }
+      table td {
+        padding: 10px 0;
+        border-bottom: 1px #ccc solid;
+      }
     </style>
   {{/head}}
   {{$main}}


### PR DESCRIPTION
* Removes edit buttons
* Adds padding and border to table rows
* Preserves line breaks in content

I was looking at https://jira.digital.homeoffice.gov.uk/browse/FLHO-482 which seems to be not a bug, but while the data was all there, the formatting was a bit off. This makes it a bit better.

### Before:

<img width="1211" alt="screen shot 2017-06-16 at 09 01 14" src="https://user-images.githubusercontent.com/117398/27217656-acde0986-5272-11e7-9296-7a0c9ae38c10.png">

### After:

<img width="1242" alt="screen shot 2017-06-16 at 09 03 00" src="https://user-images.githubusercontent.com/117398/27217671-b4a8de20-5272-11e7-8c3b-34e38e2ecfe6.png">
