### PR TITLE
Check for empty supporting docs on S5 confirm page

### DIFF
--- a/apps/new-dealer/controllers/confirm.js
+++ b/apps/new-dealer/controllers/confirm.js
@@ -130,7 +130,7 @@ module.exports = class ConfirmController extends Controller {
   }
 
   getSupportingDocuments(data, translate) {
-    if (!data['supporting-documents'] || !data['supporting-documents']) {
+    if (!data['supporting-documents'] || !data['supporting-documents'].length) {
       return null;
     }
     const items = data['supporting-documents'].map(doc => ({


### PR DESCRIPTION
If there are no supporting documents, but the array is present due to there previously having been documents (which were then deleted) then the supporting documents section of the check answers page should not be rendered.