### PR TITLE
Add 500.html template to be rendered on 500 error

### DIFF
--- a/apps/common/translations/src/en/buttons.json
+++ b/apps/common/translations/src/en/buttons.json
@@ -1,5 +1,7 @@
 {
   "delete": "Delete",
   "submit": "Submit application",
-  "find-address": "Find address"
+  "find-address": "Find address",
+  "start-again": "Start again",
+  "try-again": "Try again"
 }

--- a/apps/common/views/500.html
+++ b/apps/common/views/500.html
@@ -1,0 +1,14 @@
+{{<layout}}
+  {{$header}}
+    {{content.title}}
+  {{/header}}
+  {{$content}}
+    <p>{{{content.message}}}</p>
+    <a href="/{{startLink}}" class="button" role="button">{{#t}}buttons.try-again{{/t}}</a>
+    {{#showStack}}
+      <pre>
+        {{error.stack}}
+      </pre>
+    {{/showStack}}
+  {{/content}}
+{{/layout}}


### PR DESCRIPTION
- make use of the latest error middleware which will
lookup your local template based on the status code.

- use the latest middleware to render 500 template
so server errors can use a different button text. ("Try again")

Depends on https://github.com/UKHomeOfficeForms/hof-middleware/pull/26