### PR TITLE
Allow users to cancel out of an upload journey

### DIFF
--- a/apps/common/controllers/supporting-documents.js
+++ b/apps/common/controllers/supporting-documents.js
@@ -9,6 +9,15 @@ const uuid = require('uuid');
 const path = require('path');
 
 module.exports = class UploadController extends BaseController {
+
+  get(req, res, next) {
+    const docs = req.sessionModel.get('supporting-documents') || [];
+    if (docs.length) {
+      this.emit('complete', req, res);
+    }
+    super.get(req, res, next);
+  }
+
   process(req, res, next) {
     const file = req.files['supporting-document-upload'];
     if (file && file.truncated) {

--- a/apps/common/translations/src/en/buttons.json
+++ b/apps/common/translations/src/en/buttons.json
@@ -1,5 +1,6 @@
 {
   "delete": "Delete",
   "submit": "Submit application",
-  "find-address": "Find address"
+  "find-address": "Find address",
+  "upload-file": "Upload file"
 }

--- a/apps/common/translations/src/en/pages.json
+++ b/apps/common/translations/src/en/pages.json
@@ -33,6 +33,7 @@
     }
   },
   "supporting-documents": {
-    "guidance": "File types and sizes we accept"
+    "guidance": "File types and sizes we accept",
+    "cancel": "Don't upload and continue"
   }
 }

--- a/apps/common/views/supporting-documents.html
+++ b/apps/common/views/supporting-documents.html
@@ -8,6 +8,9 @@
       {{#renderField}}{{/renderField}}
     {{/fields}}
     {{> partials-supporting-documents-guidance}}
-    {{#input-submit}}continue{{/input-submit}}
+    <p>{{#input-submit}}upload-file{{/input-submit}}</p>
+    {{#values.supporting-documents.length}}
+    <p><a href="{{nextPage}}">{{#t}}pages.supporting-documents.cancel{{/t}}</a></p>
+    {{/values.supporting-documents.length}}
   {{/page-content}}
 {{/partials-page}}


### PR DESCRIPTION
If a user has previously uploaded documents, and selects "Yes" to upload more documents then allow them to cancel and continue with their journey without adding more documents.

Do this by marking the upload step as complete on `get` if there are documents on the session. This allows the user to go directly to the next step without completing the form.