### PR TITLE
Prevent further execution on upload auth error

### DIFF
--- a/apps/common/models/file-upload.js
+++ b/apps/common/models/file-upload.js
@@ -59,7 +59,7 @@ module.exports = class UploadModel extends Model {
     return new Promise((resolve, reject) => {
       this._request(tokenReq, (err, response) => {
         if (err) {
-          reject(err);
+          return reject(err);
         }
         resolve({
           'bearer': JSON.parse(response.body).access_token


### PR DESCRIPTION
If an error was returned from keycloak auth then the promise was being rejected but execution was allowed to continue. This caused the code immediately below to error and cause a crash as `response` is undefined in an error case.

Add the missing `return` statement to prevent this.