### PR TITLE
Add `Customer.Email` field to S5 icasework submission

### DIFF
--- a/apps/new-dealer/models/submission.js
+++ b/apps/new-dealer/models/submission.js
@@ -36,6 +36,7 @@ module.exports = data => {
   response['Agent.Address'] = data[`${addressKey}-address-manual`] || data[`${addressKey}-address-lookup`];
 
   response['Agent.Name'] = data[`${contactKey}-name`];
+  response['Customer.Email'] = data['contact-email'];
   response['Agent.Email'] = data['contact-email'];
   response['Agent.Phone'] = data['contact-phone'];
 


### PR DESCRIPTION
This is needed to be able to retrieve the email address from the `getcasedetails` API later when uploading supporting documents retrospectively.