### PR TITLE
Log error header on icasework failure

### DIFF
--- a/apps/common/behaviours/casework-submission.js
+++ b/apps/common/behaviours/casework-submission.js
@@ -41,7 +41,7 @@ module.exports = config => {
           })
           .catch(e => {
             req.log('error', `Casework submission failed: ${e.status}`);
-            req.log('error', e.body);
+            req.log('error', e.headers && e.headers['x-application-error-info']);
             next(e);
           });
       });

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "hof-confirm-controller": "^1.0.2",
     "hof-controllers": "^6.0.3",
     "hof-form-controller": "^5.1.0",
-    "hof-model": "^3.1.0",
+    "hof-model": "^3.1.2",
     "hof-theme-govuk": "^2.0.4",
     "hof-util-countries": "^1.0.0",
     "html-pdf": "^2.1.0",


### PR DESCRIPTION
icasework don't send anything useful in the response body for submission failures, so instead log the custom header they use for error messaging.