### PR TITLE
Set `AuthorityType` parameter on S5 iCasework submission

### DIFF
--- a/apps/new-dealer/models/submission.js
+++ b/apps/new-dealer/models/submission.js
@@ -1,13 +1,13 @@
 'use strict';
 /* eslint complexity: 0 max-statements: 0 */
-const contains = (arr, val) => arr.indexOf(val) > -1 ? 'Yes' : 'No';
+const contains = (arr, val) => arr.includes(val) ? 'Yes' : 'No';
 
 const authorityType = usage => {
-  if (usage.indexOf('arm-guards') > -1) {
+  if (usage.includes('arm-guards')) {
     return 'Maritime Guards';
   }
 
-  if (usage.indexOf('transport') > -1 || usage.indexOf('transfer') > -1) {
+  if (usage.includes('transport') || usage.includes('transfer')) {
     // check if any other values are selected
     if (usage.filter(use => use !== 'transport' && use !== 'transfer').length) {
       return 'Carriers and Dealers';
@@ -57,9 +57,9 @@ module.exports = data => {
   response['Agent.Email'] = data['contact-email'];
   response['Agent.Phone'] = data['contact-phone'];
 
-  if (data['weapons-ammunition'].indexOf('weapons') > -1) {
+  if (data['weapons-ammunition'].includes('weapons')) {
     response.AuthorityCoversWeapons = 'Yes';
-    if (data['weapons-types'].indexOf('unspecified') > -1) {
+    if (data['weapons-types'].includes('unspecified')) {
       response.WeaponsUnspecified = 'Yes';
       response.WeaponsUnspecifiedReason = data['weapons-unspecified-details'];
     }
@@ -78,16 +78,16 @@ module.exports = data => {
       'projecting-launchers': 'WeaponsS1A-c'
     };
     Object.keys(types).forEach(key => {
-      if (data['weapons-types'].indexOf(key) > -1) {
+      if (data['weapons-types'].includes(key)) {
         response[types[key]] = 'Yes';
         response[`${types[key]}Quantity`] = data[`${key}-quantity`];
       }
     });
   }
 
-  if (data['weapons-ammunition'].indexOf('ammunition') > -1) {
+  if (data['weapons-ammunition'].includes('ammunition')) {
     response.AuthorityCoversAmmunition = 'Yes';
-    if (data['ammunition-types'].indexOf('unspecified') > -1) {
+    if (data['ammunition-types'].includes('unspecified')) {
       response.AmmunitionUnspecified = 'Yes';
       response.AmmunitionUnspecifiedReason = data['ammunition-unspecified-details'];
     }
@@ -100,7 +100,7 @@ module.exports = data => {
       'missiles-for-above': 'AmmunitionS1A-g'
     };
     Object.keys(types).forEach(key => {
-      if (data['ammunition-types'].indexOf(key) > -1) {
+      if (data['ammunition-types'].includes(key)) {
         response[types[key]] = 'Yes';
         response[`${types[key]}Quantity`] = data[`${key}-quantity`];
       }

--- a/apps/new-dealer/models/submission.js
+++ b/apps/new-dealer/models/submission.js
@@ -2,10 +2,27 @@
 /* eslint complexity: 0 max-statements: 0 */
 const contains = (arr, val) => arr.indexOf(val) > -1 ? 'Yes' : 'No';
 
+const authorityType = usage => {
+  if (usage.indexOf('arm-guards') > -1) {
+    return 'Maritime Guards';
+  }
+
+  if (usage.indexOf('transport') > -1 || usage.indexOf('transfer') > -1) {
+    // check if any other values are selected
+    if (usage.filter(use => use !== 'transport' && use !== 'transfer').length) {
+      return 'Carriers and Dealers';
+    }
+    return 'Carriers';
+  }
+
+  return 'Dealer';
+};
+
 module.exports = data => {
   const response = {};
 
-  response.AuthorityType = 'Dealer';
+  response.AuthorityType = authorityType(data.usage);
+
   response.ApplicationType = data.activity === 'new' ? 'Application' : 'Renewal';
 
   response['Customer.Organisation'] = data[`${data.organisation}-name`];

--- a/test/new-dealer/models/submission.test.js
+++ b/test/new-dealer/models/submission.test.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const prepare = require('../../../apps/new-dealer/models/submission');
+
+describe('S5 Submission Model', () => {
+
+  describe('Authority Type', () => {
+
+    const defaults = {
+      'weapons-ammunition': [],
+      'weapons-type': [],
+      obtain: []
+    };
+
+    it('sets authority type to `Maritime Guards` if usage is to arm guards', () => {
+
+      const input = Object.assign({}, defaults, {
+        usage: [
+          'arm-guards'
+        ]
+      });
+
+      const output = prepare(input);
+
+      expect(output.AuthorityType).to.equal('Maritime Guards');
+    });
+
+    it('sets authority type to `Maritime Guards` if usage is to arm guards and any other usage', () => {
+
+      const input = Object.assign({}, defaults, {
+        usage: [
+          'transport',
+          'arm-guards'
+        ]
+      });
+
+      const output = prepare(input);
+
+      expect(output.AuthorityType).to.equal('Maritime Guards');
+    });
+
+    it('sets authority type to `Carriers` if usage is to transport', () => {
+
+      const input = Object.assign({}, defaults, {
+        usage: [
+          'transport'
+        ]
+      });
+
+      const output = prepare(input);
+
+      expect(output.AuthorityType).to.equal('Carriers');
+    });
+
+    it('sets authority type to `Carriers` if usage is to transfer', () => {
+
+      const input = Object.assign({}, defaults, {
+        usage: [
+          'transfer'
+        ]
+      });
+
+      const output = prepare(input);
+
+      expect(output.AuthorityType).to.equal('Carriers');
+    });
+
+    it('sets authority type to `Carriers and Dealers` if usage is to transfer and any other usage', () => {
+
+      const input = Object.assign({}, defaults, {
+        usage: [
+          'sell',
+          'transfer'
+        ]
+      });
+
+      const output = prepare(input);
+
+      expect(output.AuthorityType).to.equal('Carriers and Dealers');
+    });
+
+    it('sets authority type to `Carriers and Dealers` if usage is to transport and any other usage', () => {
+
+      const input = Object.assign({}, defaults, {
+        usage: [
+          'deactivation',
+          'transport'
+        ]
+      });
+
+      const output = prepare(input);
+
+      expect(output.AuthorityType).to.equal('Carriers and Dealers');
+    });
+
+    it('sets authority type to `Dealer` if usage is any other usage', () => {
+
+      const input = Object.assign({}, defaults, {
+        usage: [
+          'sell',
+          'deactivation'
+        ]
+      });
+
+      const output = prepare(input);
+
+      expect(output.AuthorityType).to.equal('Dealer');
+    });
+
+  });
+
+});


### PR DESCRIPTION
The authority type parameter should be set according to the business activity of the applicant. Depending on the usage of the weapons they authirty will be classified as a dealer, carrier, dealer/carrier, or maritime guards.