### PR TITLE
Add triple braces for values being passed in translations e.g {{{values.club-secretary-name}}}

### DIFF
--- a/apps/shooting-clubs/translations/src/en/pages.json
+++ b/apps/shooting-clubs/translations/src/en/pages.json
@@ -10,7 +10,7 @@
   },
   "second-contact-name": {
     "header": "Who should we contact in {{values.club-secretary-name}}'s absence?",
-    "intro": "We need to collect the contact details of a second person, in case {{values.club-secretary-name}} is unavailable"
+    "intro": "We need to collect the contact details of a second person, in case {{{values.club-secretary-name}}} is unavailable"
   },
   "second-contact-email": {
     "header": "What are {{values.second-contact-name}}'s contact details?"


### PR DESCRIPTION
All variables are HTML escaped by default. This will return unescaped HTML to resolve the issue of apostrophes not displaying properly or any other such ASCII characters

Strangely the headers don't need the triple braces

https://jira.digital.homeoffice.gov.uk/browse/FLHO-704