### PR TITLE
Install bzip2 on docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM quay.io/ukhomeofficedigital/nodejs-base:v6
 
+RUN yum install bzip2 -y
+
 RUN mkdir /public
 
 COPY package.json /app/package.json


### PR DESCRIPTION
bzip2 is required to successfully install phantomjs because if a binary is not found locally it downloads and unzips one.