### PR TITLE
Use JSON for icasework createcase

### DIFF
--- a/apps/common/models/i-casework.js
+++ b/apps/common/models/i-casework.js
@@ -12,14 +12,7 @@ module.exports = class CaseworkModel extends Model {
   }
 
   prepare() {
-    const params = {
-      Key: config.icasework.key,
-      Signature: this.sign(),
-      Type: 'Firearms',
-      Format: 'json',
-      db: 'flcms',
-      RequestMethod: 'Online form'
-    };
+    const params = {};
 
     if (this.get('pdf-upload')) {
       params['Document1.Name'] = 'full application data';
@@ -38,7 +31,15 @@ module.exports = class CaseworkModel extends Model {
 
   save() {
     const options = this.requestConfig({});
-    options.qs = this.prepare();
+    options.qs = {
+      Key: config.icasework.key,
+      Signature: this.sign(),
+      Type: 'Firearms',
+      Format: 'json',
+      db: 'flcms',
+      RequestMethod: 'Online form'
+    };
+    options.form = this.prepare();
     options.method = 'POST';
     if (!config.icasework.secret || !config.icasework.key && config.env !== 'production') {
       return Promise.resolve({

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - EMAIL_PORT=25
       - REDIS_HOST=redis
       - REDIS_PORT=6379
-      - PDF_CONVERTER_URL=html-pdf-converter:8001
+      - PDF_CONVERTER_URL=http://html-pdf-converter:8001/convert
 
     links:
       - redis


### PR DESCRIPTION
We noticed when uploading large forms we'd hit the uri length limit in apache to icasework.

Doing it the right way using a proper payload fixes the issue now it's supported in their API