### PR TITLE
Coerce `usage` to an array before filter

### DIFF
--- a/apps/new-dealer/models/submission.js
+++ b/apps/new-dealer/models/submission.js
@@ -7,9 +7,10 @@ const authorityType = usage => {
     return 'Maritime Guards';
   }
 
+  // usage can be an array or a string
   if (usage.includes('transport') || usage.includes('transfer')) {
     // check if any other values are selected
-    if (usage.filter(use => use !== 'transport' && use !== 'transfer').length) {
+    if ([].concat(usage).filter(use => use !== 'transport' && use !== 'transfer').length) {
       return 'Carriers and Dealers';
     }
     return 'Carriers';

--- a/test/new-dealer/models/submission.test.js
+++ b/test/new-dealer/models/submission.test.js
@@ -15,9 +15,7 @@ describe('S5 Submission Model', () => {
     it('sets authority type to `Maritime Guards` if usage is to arm guards', () => {
 
       const input = Object.assign({}, defaults, {
-        usage: [
-          'arm-guards'
-        ]
+        usage: 'arm-guards'
       });
 
       const output = prepare(input);
@@ -42,9 +40,7 @@ describe('S5 Submission Model', () => {
     it('sets authority type to `Carriers` if usage is to transport', () => {
 
       const input = Object.assign({}, defaults, {
-        usage: [
-          'transport'
-        ]
+        usage: 'transport'
       });
 
       const output = prepare(input);
@@ -55,9 +51,7 @@ describe('S5 Submission Model', () => {
     it('sets authority type to `Carriers` if usage is to transfer', () => {
 
       const input = Object.assign({}, defaults, {
-        usage: [
-          'transfer'
-        ]
+        usage: 'transfer'
       });
 
       const output = prepare(input);
@@ -105,6 +99,17 @@ describe('S5 Submission Model', () => {
       const output = prepare(input);
 
       expect(output.AuthorityType).to.equal('Dealer');
+    });
+
+    it('usage can be a string', () => {
+
+      const input = Object.assign({}, defaults, {
+        usage: 'transfer'
+      });
+
+      const output = prepare(input);
+
+      expect(output.AuthorityType).to.equal('Carriers');
     });
 
   });


### PR DESCRIPTION
Because `usage` can be either an array or a string this amend concats `usage` to an array, so that `filter()` can be invoked

This was throwing unhandled errors and causing the app not to respond