### PR TITLE
Throw timeout errors when calling icasework apis

### DIFF
--- a/apps/common/models/i-casework.js
+++ b/apps/common/models/i-casework.js
@@ -7,6 +7,11 @@ const config = require('../../../config');
 
 module.exports = class CaseworkModel extends Model {
 
+  constructor(attributes, options) {
+    super(attributes, options);
+    this.options.timeout = this.options.timeout || 20000;
+  }
+
   url() {
     return config.icasework.url + config.icasework.createpath;
   }

--- a/apps/common/models/i-casework.js
+++ b/apps/common/models/i-casework.js
@@ -9,7 +9,7 @@ module.exports = class CaseworkModel extends Model {
 
   constructor(attributes, options) {
     super(attributes, options);
-    this.options.timeout = this.options.timeout || 20000;
+    this.options.timeout = this.options.timeout || config.icasework.timeout;
   }
 
   url() {

--- a/apps/supporting-documents/behaviours/get-case.js
+++ b/apps/supporting-documents/behaviours/get-case.js
@@ -7,14 +7,18 @@ module.exports = superclass => class extends superclass {
   saveValues(req, res, next) {
     const model = new Model(req.form.values);
     model.fetch()
-      .catch(() => {
+      .catch(e => {
+        if (e.code.match(/TIMEDOUT/)) {
+          throw e;
+        }
         return {};
       })
       .then(data => {
         req.sessionModel.set('original-email', data.email);
         req.sessionModel.set('original-name', data.name);
         super.saveValues(req, res, next);
-      });
+      })
+      .catch(e => next(e));
   }
 
 };

--- a/config.js
+++ b/config.js
@@ -41,12 +41,12 @@ module.exports = {
     password: process.env.REDIS_PASSWORD
   },
   icasework: {
-    url: process.env.ICASEWORK_URL || 'https://uat.icasework.com',
     createpath: '/createcase',
     uploadpath: '/uploaddocuments',
     getcasepath: '/getcasedetails',
     key: process.env.ICASEWORK_KEY,
-    secret: process.env.ICASEWORK_SECRET
+    secret: process.env.ICASEWORK_SECRET,
+    timeout: process.env.ICASEWORK_TIMEOUT || 20000
   },
   survey: {
     urls: {


### PR DESCRIPTION
Failures of IP whitelisting with icasework manifest with a long pause (request takes ~120s) followed by an nginx "bad gateway" error due to it hitting its default timeout.

By setting an explicit timeout on our calls to icasework we can send a timeout error page before nginx fails, and so prevent the nginx error page from displaying.

Additionally we prevent catching the error when calling `getcasedetails` and so allow the app to fail early - rather than allowing the user to continue and then displaying an incorrect credentials error later. Since the timeout error is not related to sending a good or bad reference this does not represent a security issue.