### PR TITLE
Upgrade hof build & gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ public
 .idea
 coverage
 package-lock.json
+.env
+output/

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "express": "^4.15.3",
     "hof": "^12.1.1",
     "hof-behaviour-emailer": "^2.0.0",
-    "hof-build": "^1.3.4",
+    "hof-build": "^1.6.0",
     "hof-confirm-controller": "^1.0.2",
     "hof-controllers": "^6.0.3",
     "hof-form-controller": "^5.1.0",


### PR DESCRIPTION
- Upgrade hof-build to 1.6.0 to use the .env file 
- gitignore .env output/