### PR TITLE
[FLHO-724] - Fix session timeout link

### DIFF
--- a/apps/new-dealer/acceptance/features/session-error.js
+++ b/apps/new-dealer/acceptance/features/session-error.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const baseUrl = require('../../').baseUrl || '';
+
+Feature('Given my session has expired');
+
+Scenario('When I click the start again button Then I am redirected to the first page /activity', (
+  I
+) => {
+  I.amOnPage(`${baseUrl}`);
+  I.clearCookie('hod.sid');
+  I.refreshPage();
+  I.click('a[href="/s5"]');
+  I.seeInCurrentUrl(`${baseUrl}/activity`);
+});

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "busboy-body-parser": "^0.3.0",
     "debug": "^2.6.8",
     "express": "^4.15.3",
-    "hof": "^12.1.1",
+    "hof": "^13.2.1",
     "hof-behaviour-emailer": "^2.0.0",
     "hof-build": "^1.6.0",
     "hof-confirm-controller": "^1.0.2",


### PR DESCRIPTION
On a session timeout, ensure the "Start again" link returns users to the correct URL

https://jira.digital.homeoffice.gov.uk/browse/FLHO-724