### PR TITLE
SD-855 update cookie banner to reflect service

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,6 +44,15 @@ const app = hof(options);
 
 app.use((req, res, next) => addGenericLocals(req, res, next));
 
+app.use('/museums', (req, res, next) => {
+  res.locals.serviceName = 'Apply for a museum firearms licence';
+  next();
+});
+
+app.use('/shooting-clubs', (req, res, next) => {
+  res.locals.serviceName = 'Apply for shooting club approval';
+  next();
+});
 
 if (config.env !== 'production') {
   app.use(mockAPIs);


### PR DESCRIPTION
# What
A change so that the cookie banner reflects which service the user is on.

# Why
The cookie banner was showing the incorrect service title for the museums and shooting-clubs route

# How 
update to app.js to set the service name depending on the route 