### PR TITLE
FA-33: Added 'Vary' to the activity page for shooting-clubs, new-dealer and museums.

### DIFF
--- a/apps/common/controllers/base.js
+++ b/apps/common/controllers/base.js
@@ -7,7 +7,7 @@ module.exports = class BaseController extends Controller {
   locals(req, res) {
     const locals = super.locals(req, res);
     const activity = req.sessionModel.get('activity');
-    const renew = (activity === 'renew' || activity === 'vary') && locals.renew === true;
+    const renew = (activity === 'renew' || activity === 'vary') && locals.renew;
     const fields = locals.fields.filter(field => !req.form.options.fields[field.key].dependent);
     const usage = req.sessionModel.get('usage') || [];
     return Object.assign({}, locals, {

--- a/apps/common/controllers/base.js
+++ b/apps/common/controllers/base.js
@@ -6,7 +6,8 @@ module.exports = class BaseController extends Controller {
 
   locals(req, res) {
     const locals = super.locals(req, res);
-    const renew = req.sessionModel.get('activity') === 'renew' && locals.renew === true;
+    const activity = req.sessionModel.get('activity');
+    const renew = (activity === 'renew' || activity === 'vary') && locals.renew === true;
     const fields = locals.fields.filter(field => !req.form.options.fields[field.key].dependent);
     const usage = req.sessionModel.get('usage') || [];
     return Object.assign({}, locals, {

--- a/apps/common/fields/index.js
+++ b/apps/common/fields/index.js
@@ -9,7 +9,8 @@ module.exports = {
     },
     options: [
       'new',
-      'renew'
+      'renew',
+      'vary'
     ]
   },
   'reference-number': {

--- a/apps/common/translations/src/en/fields.json
+++ b/apps/common/translations/src/en/fields.json
@@ -6,6 +6,9 @@
       },
       "renew": {
         "label": "Renew or amend an existing authority"
+      },
+      "vary": {
+        "label": "Vary an existing authority"
       }
     }
   },

--- a/apps/museums/index.js
+++ b/apps/museums/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const config = require('../../config');
+const _ = require('lodash');
 
 const AddressLookup = require('../common/controllers/address/helper');
 const exhibitAddressLookup = AddressLookup({
@@ -50,8 +51,9 @@ module.exports = {
       forks: [{
         target: '/authority-details',
         condition: {
-          field: 'activity',
-          value: 'renew'
+          condition: req => {
+            return _.includes(['vary', 'renew'], req.sessionModel.get('activity'));
+          }
         }
       }]
     },

--- a/apps/museums/models/submission.js
+++ b/apps/museums/models/submission.js
@@ -1,13 +1,21 @@
 'use strict';
 
+const _ = require('lodash');
+
 module.exports = data => {
   const response = {};
+  const activity = [
+    { activity: 'new', response: 'Application' },
+    { activity: 'renew', response: 'Renewal' },
+    { activity: 'vary', response: 'Vary' }
+  ];
 
   response.AuthorityType = 'Museums';
-  response.ApplicationType = data.activity === 'new' ? 'Application' : 'Renewal';
+  response.ApplicationType = data.activity ?
+    _.find(activity, { 'activity': data.activity }).response : 'Renewal';
 
-  if (data.activity === 'renew') {
-    response['Cusomter.CustomerReference'] = data['reference-number'];
+  if (data.activity === 'renew' || data.activity === 'vary') {
+    response['Customer.CustomerReference'] = data['reference-number'];
     response.ExistingAuthorityReference = data['authority-number'];
   }
 

--- a/apps/new-dealer/index.js
+++ b/apps/new-dealer/index.js
@@ -44,9 +44,8 @@ module.exports = {
       next: '/company-name',
       forks: [{
         target: '/authority-number-renew-vary',
-        condition: {
-          field: 'activity',
-          value: 'renew'
+        condition: req => {
+          return _.includes(['vary', 'renew'], req.sessionModel.get('activity'));
         }
       }]
     },

--- a/apps/new-dealer/models/submission.js
+++ b/apps/new-dealer/models/submission.js
@@ -1,5 +1,7 @@
 'use strict';
 /* eslint complexity: 0 max-statements: 0 */
+
+const _ = require('lodash');
 const contains = (arr, val) => arr.includes(val) ? 'Yes' : 'No';
 
 const authorityType = usage => {
@@ -21,14 +23,19 @@ const authorityType = usage => {
 
 module.exports = data => {
   const response = {};
+  const activity = [
+    { activity: 'new', response: 'Application' },
+    { activity: 'renew', response: 'Renewal' },
+    { activity: 'vary', response: 'Vary' }
+  ];
 
   response.AuthorityType = authorityType(data.usage);
-
-  response.ApplicationType = data.activity === 'new' ? 'Application' : 'Renewal';
+  response.ApplicationType = data.activity ?
+    _.find(activity, { 'activity': data.activity }).response : 'Renewal';
 
   response['Customer.Organisation'] = data[`${data.organisation}-name`];
 
-  if (data.activity === 'renew') {
+  if (data.activity === 'renew' || data.activity === 'vary') {
     response['Customer.CustomerReference'] = data['reference-number'];
     response.ExistingAuthorityReference = data['authority-number'];
   }

--- a/apps/shooting-clubs/index.js
+++ b/apps/shooting-clubs/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const config = require('../../config');
+const _ = require('lodash');
 
 const AddressLookup = require('../common/controllers/address/helper');
 
@@ -73,9 +74,8 @@ module.exports = {
       next: '/new-club',
       forks: [{
         target: '/authority-details',
-        condition: {
-          field: 'activity',
-          value: 'renew'
+        condition: req => {
+          return _.includes(['vary', 'renew'], req.sessionModel.get('activity'));
         }
       }]
     },

--- a/apps/shooting-clubs/models/submission.js
+++ b/apps/shooting-clubs/models/submission.js
@@ -1,12 +1,19 @@
 'use strict';
+const _ = require('lodash');
 
 module.exports = data => {
   const response = {};
+  const activity = [
+    { activity: 'new', response: 'Application' },
+    { activity: 'renew', response: 'Renewal' },
+    { activity: 'vary', response: 'Vary' }
+  ];
 
   response.AuthorityType = 'Shooting clubs';
-  response.ApplicationType = data.activity === 'new' ? 'Application' : 'Renewal';
+  response.ApplicationType = data.activity ?
+    _.find(activity, { 'activity': data.activity }).response : 'Renewal';
 
-  if (data.activity === 'renew') {
+  if (data.activity === 'renew' || data.activity === 'vary') {
     response['Cusomter.CustomerReference'] = data['reference-number'];
     response.ExistingAuthorityReference = data['authority-number'];
   }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "url": "https://github.com/UKHomeOffice/firearms"
   },
+  "engines": {
+    "node": "14.16.1"
+  },
   "license": "./LICENSE",
   "readme": "./README.md",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
     "type": "git",
     "url": "https://github.com/UKHomeOffice/firearms"
   },
-  "engines": {
-    "node": "14.16.1"
-  },
   "license": "./LICENSE",
   "readme": "./README.md",
   "scripts": {

--- a/test/common/controllers/base.test.js
+++ b/test/common/controllers/base.test.js
@@ -65,6 +65,13 @@ describe('BaseController', () => {
           baseController.locals(req, res).renew.should.be.true;
         });
 
+        it('sets renew to true if activity is vary and super.locals.renew is true', () => {
+          req.sessionModel.get.returns('vary');
+          FormController.prototype.locals.returns({renew: true, fields: []});
+
+          baseController.locals(req, res).renew.should.be.true;
+        });
+
         it('sets renew to false if activity is not true and super.locals.renew is true', () => {
           req.sessionModel.get.returns('foo');
           FormController.prototype.locals.returns({renew: true, fields: []});
@@ -72,8 +79,15 @@ describe('BaseController', () => {
           baseController.locals(req, res).renew.should.be.false;
         });
 
-        it('sets renew to true if activity is renew and super.locals.renew is true', () => {
+        it('sets renew to false if activity is renew and super.locals.renew is false', () => {
           req.sessionModel.get.returns('renew');
+          FormController.prototype.locals.returns({renew: false, fields: []});
+
+          baseController.locals(req, res).renew.should.be.false;
+        });
+
+        it('sets renew to false if activity is vary and super.locals.renew is false', () => {
+          req.sessionModel.get.returns('vary');
           FormController.prototype.locals.returns({renew: false, fields: []});
 
           baseController.locals(req, res).renew.should.be.false;


### PR DESCRIPTION
**Changes**

            * Added 'Vary' selection to shooting-clubs, new-dealer and museums index.js pages.
            * Updated fields.json to include new option.
            * Updated submission.js in shooting-clubs, new-dealer and museums logic for new option.
            * Updated index.js in shooting-clubs, new-dealer and museums for new fork step which follows the same as 'renew'.
            * Added additional unit tests for 'vary' in base.test.js
            * Changed find in submission.js for shooting-clubs, new-dealer and museums