### PR TITLE
FA-85 and 86: Missing label for invoice address for postcode lookup page and support for uppercase file extensions for document uploaders

### DIFF
--- a/apps/museums/translations/src/en/fields.json
+++ b/apps/museums/translations/src/en/fields.json
@@ -58,6 +58,9 @@
   "invoice-address-manual": {
     "label": "Address"
   },
+  "invoice-address-select": {
+    "label": "Select the address"
+  },
   "contact-address": {
     "legend": "Address"
   },

--- a/apps/new-dealer/translations/src/en/fields.json
+++ b/apps/new-dealer/translations/src/en/fields.json
@@ -463,6 +463,9 @@
   "invoice-address-manual": {
     "label": "Address"
   },
+  "invoice-address-select": {
+    "label": "Select the address"
+  },
   "invoice-address": {
     "label": "Address"
   },

--- a/apps/shooting-clubs/translations/src/en/fields.json
+++ b/apps/shooting-clubs/translations/src/en/fields.json
@@ -129,6 +129,9 @@
   "invoice-address-manual": {
     "label": "Address"
   },
+  "invoice-address-select": {
+    "label": "Select the address"
+  },
   "contact-address": {
     "legend": "Address"
   },

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -82,7 +82,7 @@ spec:
                   name: ses
                   key: password
             - name: FILE_EXTENSION_WHITELIST
-              value: 'pdf,doc,docx,txt,jpg,jpeg,png,xls,xlsx,odt,ods'
+              value: 'pdf,doc,docx,txt,jpg,jpeg,png,xls,xlsx,odt,ods,PDF,DOC,DOCX,TXT,JPG,JPEG,PNG,XLS,XLSX,ODT,ODS'
           securityContext:
             runAsNonRoot: true
 

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: file-vault
-          image: quay.io/ukhomeofficedigital/file-vault:bab000624c4323823cd4df723b44bc3bd29fec2c
+          image: quay.io/ukhomeofficedigital/file-vault:ff139ae0ebaa279d51bc75610fc7999c2658450a
           imagePullPolicy: Always
           resources:
             requests:
@@ -82,7 +82,7 @@ spec:
                   name: ses
                   key: password
             - name: FILE_EXTENSION_WHITELIST
-              value: 'pdf,doc,docx,txt,jpg,jpeg,png,xls,xlsx,odt,ods,PDF,DOC,DOCX,TXT,JPG,JPEG,PNG,XLS,XLSX,ODT,ODS'
+              value: 'pdf,doc,docx,txt,jpg,jpeg,png,xls,xlsx,odt,ods'
           securityContext:
             runAsNonRoot: true
 


### PR DESCRIPTION
**Changes**	

Added missing label for invoice address for postcode lookup page.

- invoice-address-select label added to fields.js for all forms.

 Support added for PDF files extensions for file-vault.
    
- file-vault-deployment.yml changed to include support for file extensions in upper and mixed case, via a file-vault update. 
