### PR TITLE
Changes to ensure validation message shows for when a file is over the max file size limit.

### DIFF
--- a/apps/common/controllers/existing-authority-documents.js
+++ b/apps/common/controllers/existing-authority-documents.js
@@ -17,10 +17,10 @@ module.exports = class UploadController extends BaseController {
     super.get(req, res, next);
   }
 
-  process(req, res, next) {
+  async process(req, res, next) {
     const file = req.files['existing-authority-upload'];
     if (file && file.truncated) {
-      const err = new this.ValidationError('existing-authority-upload', {
+      const err = await new this.ValidationError('existing-authority-upload', {
         type: 'filesize',
         arguments: [config.upload.maxfilesize]
       }, req, res);

--- a/apps/common/controllers/supporting-documents.js
+++ b/apps/common/controllers/supporting-documents.js
@@ -17,10 +17,10 @@ module.exports = class UploadController extends BaseController {
     super.get(req, res, next);
   }
 
-  process(req, res, next) {
+  async process(req, res, next) {
     const file = req.files['supporting-document-upload'];
     if (file && file.truncated) {
-      const err = new this.ValidationError('supporting-document-upload', {
+      const err = await new this.ValidationError('supporting-document-upload', {
         type: 'filesize',
         arguments: [config.upload.maxfilesize]
       }, req, res);

--- a/apps/common/views/content/existing-authority-documents-guidance.md
+++ b/apps/common/views/content/existing-authority-documents-guidance.md
@@ -1,4 +1,4 @@
-Each document can be up to 100MB in size.
+Each document can be up to 50MB in size.
 
 We accept these file types:
 

--- a/apps/common/views/content/supporting-documents-guidance.md
+++ b/apps/common/views/content/supporting-documents-guidance.md
@@ -1,4 +1,4 @@
-Each document can be up to 100MB in size.
+Each document can be up to 50MB in size.
 
 We accept these file types:
 

--- a/config.js
+++ b/config.js
@@ -7,7 +7,7 @@ const localhost = () => `${process.env.LISTEN_HOST || '0.0.0.0'}:${process.env.P
 module.exports = {
   env: env,
   upload: {
-    maxfilesize: '100mb',
+    maxfilesize: '50mb',
     hostname: (!env || env === 'ci') ?
       `http://${localhost()}/api/file-upload` :
       process.env.FILE_VAULT_URL

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: file-vault
-          image: quay.io/ukhomeofficedigital/file-vault:ff139ae0ebaa279d51bc75610fc7999c2658450a
+          image: quay.io/ukhomeofficedigital/file-vault:7fa14bd39273647de4e15efb1b2ca546257cf0b3
           imagePullPolicy: Always
           resources:
             requests:
@@ -83,6 +83,10 @@ spec:
                   key: password
             - name: FILE_EXTENSION_WHITELIST
               value: 'pdf,doc,docx,txt,jpg,jpeg,png,xls,xlsx,odt,ods'
+            - name: MAX_FILE_SIZE
+              value: '2048000'
+            - name: REQUEST_TIMEOUT
+              value: '260'
           securityContext:
             runAsNonRoot: true
 

--- a/test/_unit/new-dealer/controllers/existing-authority-documents-validation.spec.js
+++ b/test/_unit/new-dealer/controllers/existing-authority-documents-validation.spec.js
@@ -1,0 +1,154 @@
+/* eslint no-unused-vars: 1 */
+const Base = require('../../../../apps/common/controllers/base');
+const UploadModel = require('../../../../apps/common/models/file-upload');
+const Controller = proxyquire('../apps/common/controllers/existing-authority-documents', {
+  uuid: { v1: () => 'abc123' }
+});
+
+const request = reqres.req;
+const response = reqres.res;
+
+describe('Existing Authority Documents Controller', () => {
+  let sandbox;
+
+  it('extends the base controller', () => {
+    controller = new Controller({});
+    expect(controller).to.be.an.instanceOf(Base);
+  });
+
+  beforeEach(function () {
+    sandbox = sinon.createSandbox();
+    sandbox.stub(UploadModel.prototype, 'save').returns(new Promise(resolve => {
+      resolve({url: 'http://example.com/file/upload'});
+    }));
+    sandbox.stub(UploadModel.prototype, 'set').returns();
+    sandbox.stub(Controller.prototype, 'process').returns();
+  });
+
+  afterEach(() => sandbox.restore());
+
+  describe('process', () => {
+    it('calls base controllers `process` method by default', () => {
+      controller = new Controller({});
+      const req = request();
+      const res = response();
+      const next = sinon.stub();
+      controller.process(req, res, next);
+
+      expect(Controller.prototype.process).to.have.been.calledOnce;
+      expect(Controller.prototype.process).to.have.been.calledWithExactly(req, res, next);
+      expect(Controller.prototype.process).to.have.been.calledOn(controller);
+    });
+
+    it('errors when the file is too big i.e. truncated', () => {
+      controller = new Controller({});
+      const req = request();
+      const res = response();
+      const files = {
+        'existing-authority-document-upload': {
+          truncated: true
+        }
+      };
+      controller.process(request({files}), {}, () => {
+        Controller.prototype.ValidationError.should.have.been.calledOnce;
+        Controller.prototype.ValidationError.should.have.been.calledWith(req, res);
+        Controller.prototype.ValidationError.should.have.been.calledWith('existing-authority-document-upload', {
+          type: 'filesize', arguments: ['50mb']
+        });
+      });
+    });
+
+    it('calls next without hitting the upload API when the file is too big', () => {
+      const controller = new Controller({});
+      const files = {
+        'existing-authority-document-upload': {
+          truncated: true
+        }
+      };
+
+      controller.process(request({files}), {}, next => {
+        Controller.prototype.save.should.have.been.called;
+        next.should.not.have.been.calledWithExactly();
+        next.should.have.been.calledOnce;
+      });
+    });
+
+    it('calls next immediately & does NOT hit the upload API if no file is uploaded', () => {
+      const controller = new Controller({});
+      const files = {
+        'existing-authority-document-upload': {
+          data: null
+        }
+      };
+
+      controller.process(request({files}), {}, next => {
+        Controller.prototype.save.should.not.been.called;
+        next.should.have.been.calledWithExactly();
+        next.should.have.been.calledOnce;
+      });
+    });
+
+    it('saves the file to the uploaded model', () => {
+      const controller = new Controller({});
+      const req = request();
+      const res = response();
+      const result = {
+        url: 'www.s3.com/foo'
+      };
+      UploadModel.prototype.save.resolves(result);
+
+      req.files = {
+        'existing-authority-document-upload': {
+          data: 'picture',
+          name: 'myfile.png',
+          mimetype: 'image/png'
+        }
+      };
+      controller.process(req, res, () => {
+        Controller.prototype.save.should.been.called;
+      });
+    });
+
+    it('saves the file data to form values', () => {
+      const controller = new Controller({});
+      const req = request();
+      const res = response();
+      const result = {
+        url: 'www.s3.com/foo'
+      };
+      UploadModel.prototype.save.resolves(result);
+
+      req.files = {
+        'existing-authority-document-upload': {
+          data: 'picture',
+          name: 'myfile.png',
+          mimetype: 'image/png'
+        }
+      };
+      controller.process(req, res, () => {
+        req.form.values['existing-authority-document-upload'].should.equal(result.url);
+      });
+    });
+
+
+    it('calls next with an error if the model errors', () => {
+      const controller = new Controller({});
+      const req = request();
+      const res = response();
+      const err = new Error('oh noes!');
+      UploadModel.prototype.save.rejects(err);
+
+      req.files = {
+        'existing-authority-document-upload': {
+          data: 'some picture',
+          name: 'myPhoto.jpg',
+          mimetype: 'image/jpg'
+        }
+      };
+
+      controller.process(req, res, e => {
+        e.should.equal(err);
+      });
+    });
+  });
+});

--- a/test/_unit/new-dealer/controllers/supporting-documents-validation.spec.js
+++ b/test/_unit/new-dealer/controllers/supporting-documents-validation.spec.js
@@ -1,0 +1,153 @@
+const Base = require('../../../../apps/common/controllers/base');
+const UploadModel = require('../../../../apps/common/models/file-upload');
+const Controller = proxyquire('../apps/common/controllers/supporting-documents', {
+  uuid: { v1: () => 'abc123' }
+});
+
+const request = reqres.req;
+const response = reqres.res;
+
+describe('Supporting Documents Controller', () => {
+  let sandbox;
+
+  it('extends the base controller', () => {
+    controller = new Controller({});
+    expect(controller).to.be.an.instanceOf(Base);
+  });
+
+  beforeEach(function () {
+    sandbox = sinon.createSandbox();
+    sandbox.stub(UploadModel.prototype, 'save').returns(new Promise(resolve => {
+      resolve({url: 'http://example.com/file/upload'});
+    }));
+    sandbox.stub(UploadModel.prototype, 'set').returns();
+    sandbox.stub(Controller.prototype, 'process').returns();
+  });
+
+  afterEach(() => sandbox.restore());
+
+  describe('process', () => {
+    it('calls base controllers `process` method by default', () => {
+      const controller = new Controller({});
+      const req = request();
+      const res = response();
+      const next = sinon.stub();
+      controller.process(req, res, next);
+
+      expect(Controller.prototype.process).to.have.been.calledOnce;
+      expect(Controller.prototype.process).to.have.been.calledWithExactly(req, res, next);
+      expect(Controller.prototype.process).to.have.been.calledOn(controller);
+    });
+
+    it('errors when the file is too big i.e. truncated', () => {
+      const controller = new Controller({});
+      const req = request();
+      const res = response();
+      const files = {
+        'supporting-document-upload': {
+          truncated: true
+        }
+      };
+      controller.process(request({files}), {}, () => {
+        Controller.prototype.ValidationError.should.have.been.calledOnce;
+        Controller.prototype.ValidationError.should.have.been.calledWith(req, res);
+        Controller.prototype.ValidationError.should.have.been.calledWith('supporting-document-upload', {
+          type: 'filesize', arguments: ['50mb']
+        });
+      });
+    });
+
+    it('calls next without hitting the upload API when the file is too big', () => {
+      const controller = new Controller({});
+      const files = {
+        'supporting-document-upload': {
+          truncated: true
+        }
+      };
+
+      controller.process(request({files}), {}, () => {
+        Controller.prototype.save.should.have.been.called;
+        next.should.not.have.been.calledWithExactly();
+        next.should.have.been.calledOnce;
+      });
+    });
+
+    it('calls next immediately & does NOT hit the upload API if no file is uploaded', () => {
+      const controller = new Controller({});
+      const files = {
+        'supporting-document-upload': {
+          data: null
+        }
+      };
+
+      controller.process(request({files}), {}, next => {
+        Controller.prototype.save.should.not.been.called;
+        next.should.have.been.calledWithExactly();
+        next.should.have.been.calledOnce;
+      });
+    });
+
+    it('saves the file to the uploaded model', () => {
+      const controller = new Controller({});
+      const req = request();
+      const res = response();
+      const result = {
+        url: 'www.s3.com/foo'
+      };
+      UploadModel.prototype.save.resolves(result);
+
+      req.files = {
+        'supporting-document-upload': {
+          data: 'picture',
+          name: 'myfile.png',
+          mimetype: 'image/png'
+        }
+      };
+      controller.process(req, res, () => {
+        Controller.prototype.save.should.been.called;
+      });
+    });
+
+    it('saves the file data to form values', () => {
+      const controller = new Controller({});
+      const req = request();
+      const res = response();
+      const result = {
+        url: 'www.s3.com/foo'
+      };
+      UploadModel.prototype.save.resolves(result);
+
+      req.files = {
+        'supporting-document-upload': {
+          data: 'picture',
+          name: 'myfile.png',
+          mimetype: 'image/png'
+        }
+      };
+      controller.process(req, res, () => {
+        req.form.values['supporting-document-upload'].should.equal(result.url);
+      });
+    });
+
+
+    it('calls next with an error if the model errors', () => {
+      const controller = new Controller({});
+      const req = request();
+      const res = response();
+      const err = new Error('oh noes!');
+      UploadModel.prototype.save.rejects(err);
+
+      req.files = {
+        'supporting-document-upload': {
+          data: 'some picture',
+          name: 'myPhoto.jpg',
+          mimetype: 'image/jpg'
+        }
+      };
+
+      controller.process(req, res, e => {
+        e.should.equal(err);
+      });
+    });
+  });
+});


### PR DESCRIPTION
**Changes**

- maxfilesize changed to 50mb in config.js
- MAX_FILE_SIZE and REQUEST_TIMEOUT added to file-vault-deployment to allow more time and to increase the maximum filesize for the clamAV scan in file-vault.
- Asynchronous problem fixed in existing anf supporting document behaviours, so we wait for a filesize check to complete before calling file-vault. This is to mitigate a 503 error being shown before the validation message is displayed.
- Markdown text changed from 100mb to 50mb for the reduced filesize.
- Added unit tests for supporting and existing-authority document controllers, to test max filesize validation.
