### PR TITLE
revert firearms-98: add underline under text

### DIFF
--- a/apps/common/views/partials/existing-authority-documents-guidance.html
+++ b/apps/common/views/partials/existing-authority-documents-guidance.html
@@ -1,6 +1,6 @@
 <details>
   <summary role="button">
-    <span>{{#t}}pages.existing-authority.guidance{{/t}}</span>
+    <span class="summary">{{#t}}pages.existing-authority.guidance{{/t}}</span>
   </summary>
   <div class="panel-indent">
     {{#markdown}}existing-authority-documents-guidance{{/markdown}}

--- a/apps/common/views/partials/supporting-documents-guidance.html
+++ b/apps/common/views/partials/supporting-documents-guidance.html
@@ -1,6 +1,6 @@
 <details>
   <summary role="button">
-    <span>{{#t}}pages.supporting-documents.guidance{{/t}}</span>
+    <span class="summary">{{#t}}pages.supporting-documents.guidance{{/t}}</span>
   </summary>
   <div class="panel-indent">
     {{#markdown}}supporting-documents-guidance{{/markdown}}

--- a/apps/new-dealer/views/partials/supporting-documents-evidence-type-guidance.html
+++ b/apps/new-dealer/views/partials/supporting-documents-evidence-type-guidance.html
@@ -1,6 +1,6 @@
 <details>
   <summary role="button">
-    <span>{{#t}}Types of evidence{{/t}}</span>
+    <span class="summary">{{#t}}Types of evidence{{/t}}</span>
   </summary>
   <div class="panel-indent">
     {{#markdown}}supporting-documents-evidence-type-guidance{{/markdown}}


### PR DESCRIPTION
## What
reverted [Firearms-98](https://github.com/UKHomeOffice/firearms/pull/360/files) so that text is underlined once more.
## Why
To keep it inline with GDS component the text does need to be underlined.
## Testing
tested locally