### PR TITLE
Firearms-3 - Added phonenumber validation rules to all phone numbers

### DIFF
--- a/apps/museums/fields/index.js
+++ b/apps/museums/fields/index.js
@@ -15,7 +15,7 @@ module.exports = {
   },
   'contact-phone': {
     mixin: 'input-text',
-    validate: ['required', 'phonenumber']
+    validate: ['required', 'internationalPhoneNumber']
   },
   'same-contact-address': {
     mixin: 'radio-group',
@@ -66,7 +66,7 @@ module.exports = {
   },
   'invoice-contact-phone': {
     mixin: 'input-text',
-    validate: ['required', 'phonenumber']
+    validate: ['required', 'internationalPhoneNumber']
   },
   'exhibit-building': {
     validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }]

--- a/apps/museums/fields/index.js
+++ b/apps/museums/fields/index.js
@@ -15,7 +15,7 @@ module.exports = {
   },
   'contact-phone': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', 'phonenumber']
   },
   'same-contact-address': {
     mixin: 'radio-group',
@@ -66,7 +66,7 @@ module.exports = {
   },
   'invoice-contact-phone': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', 'phonenumber']
   },
   'exhibit-building': {
     validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }]

--- a/apps/museums/translations/src/en/validation.json
+++ b/apps/museums/translations/src/en/validation.json
@@ -25,7 +25,7 @@
   },
   "contact-phone": {
     "required": "Enter a contact phone number",
-    "phonenumber": "Enter a valid phone number"
+    "internationalPhoneNumber": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192 "
   },
   "same-contact-address": {
     "required": "Select an option"
@@ -59,7 +59,7 @@
   },
   "invoice-contact-phone": {
     "required": "Enter a contact phone number",
-    "phonenumber": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192 "
+    "internationalPhoneNumber": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192 "
   },
   "purchase-order": {
     "required": "Select if you have a purchase order"

--- a/apps/new-dealer/fields/index.js
+++ b/apps/new-dealer/fields/index.js
@@ -623,7 +623,7 @@ module.exports = {
   },
   'contact-phone': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', 'phonenumber']
   },
   'use-different-address': {
     mixin: 'radio-group',
@@ -728,7 +728,7 @@ module.exports = {
   },
   'invoice-contact-phone': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', 'phonenumber']
   },
   'invoice-building': {
     validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }],

--- a/apps/new-dealer/fields/index.js
+++ b/apps/new-dealer/fields/index.js
@@ -623,7 +623,7 @@ module.exports = {
   },
   'contact-phone': {
     mixin: 'input-text',
-    validate: ['required', 'phonenumber']
+    validate: ['required', 'internationalPhoneNumber']
   },
   'use-different-address': {
     mixin: 'radio-group',
@@ -728,7 +728,7 @@ module.exports = {
   },
   'invoice-contact-phone': {
     mixin: 'input-text',
-    validate: ['required', 'phonenumber']
+    validate: ['required', 'internationalPhoneNumber']
   },
   'invoice-building': {
     validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }],

--- a/apps/new-dealer/translations/src/en/validation.json
+++ b/apps/new-dealer/translations/src/en/validation.json
@@ -226,7 +226,7 @@
   },
   "contact-phone": {
     "required": "Enter contact's phone number",
-    "phonenumber": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192 "
+    "internationalPhoneNumber": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192 "
   },
   "use-different-address": {
     "required": "Select an option"
@@ -271,7 +271,7 @@
   },
   "invoice-contact-phone": {
     "required": "Enter a contact phone number",
-    "phonenumber": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192 "
+    "internationalPhoneNumber": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192 "
   },
   "invoice-building": {
     "default": "Enter details of your building and street"

--- a/apps/new-dealer/translations/src/en/validation.json
+++ b/apps/new-dealer/translations/src/en/validation.json
@@ -225,7 +225,8 @@
     "email": "Enter a valid email address"
   },
   "contact-phone": {
-    "required": "Enter contact's phone number"
+    "required": "Enter contact's phone number",
+    "phonenumber": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192 "
   },
   "use-different-address": {
     "required": "Select an option"

--- a/apps/shooting-clubs/fields/index.js
+++ b/apps/shooting-clubs/fields/index.js
@@ -27,7 +27,7 @@ module.exports = {
   },
   'second-contact-phone': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', 'phonenumber']
   },
   'club-secretary-name': {
     mixin: 'input-text',
@@ -81,7 +81,7 @@ module.exports = {
   },
   'club-secretary-phone': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', 'phonenumber']
   },
   'second-contact-postcode': {
     mixin: 'input-text-code',
@@ -185,7 +185,7 @@ module.exports = {
   },
   'invoice-contact-phone': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', 'phonenumber']
   },
   'invoice-building': {
     validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }]

--- a/apps/shooting-clubs/fields/index.js
+++ b/apps/shooting-clubs/fields/index.js
@@ -27,7 +27,7 @@ module.exports = {
   },
   'second-contact-phone': {
     mixin: 'input-text',
-    validate: ['required', 'phonenumber']
+    validate: ['required', 'internationalPhoneNumber']
   },
   'club-secretary-name': {
     mixin: 'input-text',
@@ -81,7 +81,7 @@ module.exports = {
   },
   'club-secretary-phone': {
     mixin: 'input-text',
-    validate: ['required', 'phonenumber']
+    validate: ['required', 'internationalPhoneNumber']
   },
   'second-contact-postcode': {
     mixin: 'input-text-code',
@@ -185,7 +185,7 @@ module.exports = {
   },
   'invoice-contact-phone': {
     mixin: 'input-text',
-    validate: ['required', 'phonenumber']
+    validate: ['required', 'internationalPhoneNumber']
   },
   'invoice-building': {
     validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }]

--- a/apps/shooting-clubs/translations/src/en/validation.json
+++ b/apps/shooting-clubs/translations/src/en/validation.json
@@ -17,7 +17,7 @@
   },
   "second-contact-phone": {
     "required": "Enter the second person's phone number",
-    "phonenumber": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192 "
+    "internationalPhoneNumber": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192 "
   },
   "club-secretary-name": {
     "required": "Enter the name of the club secretary"
@@ -44,7 +44,7 @@
   },
   "club-secretary-phone": {
     "required": "Enter the club secretary's phone number",
-    "phonenumber": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192 "
+    "internationalPhoneNumber": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192 "
   },
   "second-contact-postcode": {
     "required": "Enter a postcode",
@@ -103,7 +103,7 @@
   },
   "invoice-contact-phone": {
     "required": "Enter a contact phone number",
-    "phonenumber": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192 "
+    "internationalPhoneNumber": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192 "
   },
   "purchase-order": {
     "required": "Select if you have a purchase order"

--- a/apps/shooting-clubs/translations/src/en/validation.json
+++ b/apps/shooting-clubs/translations/src/en/validation.json
@@ -16,7 +16,8 @@
     "email": "Enter a valid email address"
   },
   "second-contact-phone": {
-    "required": "Enter the second person's phone number"
+    "required": "Enter the second person's phone number",
+    "phonenumber": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192 "
   },
   "club-secretary-name": {
     "required": "Enter the name of the club secretary"
@@ -42,7 +43,8 @@
     "email": "Enter a valid email address"
   },
   "club-secretary-phone": {
-    "required": "Enter the club secretary's phone number"
+    "required": "Enter the club secretary's phone number",
+    "phonenumber": "Enter a phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192 "
   },
   "second-contact-postcode": {
     "required": "Enter a postcode",


### PR DESCRIPTION
What?

Lock down phone number fields to only +(0-9)

Why?
The phone number fields currently accept anything

How?
Added the phonenumber validation rule to each field

Testing?
Tested locally

Screenshots (optional)
Anything Else?