### PR TITLE
Firearms 68 - Add max length throughout service

### DIFF
--- a/apps/common/fields/index.js
+++ b/apps/common/fields/index.js
@@ -15,14 +15,15 @@ module.exports = {
   },
   'reference-number': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}]
   },
   'supporting-document-upload': {
     mixin: 'input-file',
-    validate: 'required'
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}]
   },
   'supporting-document-description': {
-    mixin: 'textarea'
+    mixin: 'textarea',
+    validate: [{'type': 'maxlength', 'arguments': [15000]}]
   },
   'supporting-document-add-another': {
     mixin: 'radio-group',
@@ -40,7 +41,8 @@ module.exports = {
     validate: 'required'
   },
   'existing-authority-description': {
-    mixin: 'textarea'
+    mixin: 'textarea',
+    validate: [{'type': 'maxlength', 'arguments': [15000]}]
   },
   'existing-authority-add-another': {
     mixin: 'radio-group',

--- a/apps/common/fields/index.js
+++ b/apps/common/fields/index.js
@@ -19,7 +19,7 @@ module.exports = {
   },
   'supporting-document-upload': {
     mixin: 'input-file',
-    validate: ['required', {'type': 'maxlength', 'arguments': [200]}]
+    validate: ['required']
   },
   'supporting-document-description': {
     mixin: 'textarea',

--- a/apps/museums/fields/index.js
+++ b/apps/museums/fields/index.js
@@ -3,11 +3,11 @@
 module.exports = {
   name: {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}]
   },
   'contact-name': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}]
   },
   'contact-email': {
     mixin: 'input-text',
@@ -15,7 +15,7 @@ module.exports = {
   },
   'contact-phone': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}]
   },
   'same-contact-address': {
     mixin: 'radio-group',
@@ -50,7 +50,7 @@ module.exports = {
     }]
   },
   'purchase-order-number': {
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     dependent: {
       field: 'purchase-order',
       value: 'Yes'
@@ -58,7 +58,7 @@ module.exports = {
   },
   'invoice-contact-name': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}]
   },
   'invoice-contact-email': {
     mixin: 'input-text',
@@ -66,57 +66,57 @@ module.exports = {
   },
   'invoice-contact-phone': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}]
   },
   'exhibit-building': {
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }]
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 200 }]
   },
   'exhibit-street': {
-    validate: ['notUrl', { type: 'maxlength', arguments: 50 }],
+    validate: ['notUrl', { type: 'maxlength', arguments: 200 }],
     labelClassName: 'visuallyhidden'
   },
   'exhibit-townOrCity': {
     validate: ['required', 'notUrl',
       { type: 'regex', arguments: /^([^0-9]*)$/ },
-      { type: 'maxlength', arguments: 100 }
+      { type: 'maxlength', arguments: 200 }
     ]
   },
   'exhibit-postcodeOrZIPCode': {
-    validate: ['required'],
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     formatter: ['removespaces', 'uppercase']
   },
   'contact-building': {
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }]
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 200 }]
   },
   'contact-street': {
-    validate: ['notUrl', { type: 'maxlength', arguments: 50 }],
+    validate: ['notUrl', { type: 'maxlength', arguments: 200 }],
     labelClassName: 'visuallyhidden'
   },
   'contact-townOrCity': {
     validate: ['required', 'notUrl',
       { type: 'regex', arguments: /^([^0-9]*)$/ },
-      { type: 'maxlength', arguments: 100 }
+      { type: 'maxlength', arguments: 200 }
     ]
   },
   'contact-postcodeOrZIPCode': {
-    validate: ['required'],
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     formatter: ['removespaces', 'uppercase']
   },
   'invoice-building': {
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }]
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 200 }]
   },
   'invoice-street': {
-    validate: ['notUrl', { type: 'maxlength', arguments: 50 }],
+    validate: ['notUrl', { type: 'maxlength', arguments: 200 }],
     labelClassName: 'visuallyhidden'
   },
   'invoice-townOrCity': {
     validate: ['required', 'notUrl',
       { type: 'regex', arguments: /^([^0-9]*)$/ },
-      { type: 'maxlength', arguments: 100 }
+      { type: 'maxlength', arguments: 200 }
     ]
   },
   'invoice-postcodeOrZIPCode': {
-    validate: ['required'],
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     formatter: ['removespaces', 'uppercase']
   }
 };

--- a/apps/new-dealer/fields/index.js
+++ b/apps/new-dealer/fields/index.js
@@ -12,7 +12,7 @@ function notBothOptions(vals) {
 module.exports = {
   'authority-number': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}]
   },
   organisation: {
     mixin: 'radio-group',
@@ -49,56 +49,56 @@ module.exports = {
     }]
   },
   'sole-trader-name': {
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     dependent: {
       field: 'organisation',
       value: 'sole-trader'
     }
   },
   'company-name': {
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     dependent: {
       field: 'organisation',
       value: 'company'
     }
   },
   'company-house-number': {
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     dependent: {
       field: 'organisation',
       value: 'company'
     }
   },
   'shooting-club-name': {
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     dependent: {
       field: 'organisation',
       value: 'shooting-club'
     }
   },
   'charity-name': {
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     dependent: {
       field: 'organisation',
       value: 'charity'
     }
   },
   'charity-number': {
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     dependent: {
       field: 'organisation',
       value: 'charity'
     }
   },
   'museum-name': {
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     dependent: {
       field: 'organisation',
       value: 'museum'
     }
   },
   'other-name': {
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     dependent: {
       field: 'organisation',
       value: 'other'
@@ -128,14 +128,14 @@ module.exports = {
     ]
   },
   'other-means-details': {
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     dependent: {
       field: 'obtain',
       value: 'other-means'
     }
   },
   'wont-take-details': {
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     dependent: {
       field: 'obtain',
       value: 'wont-take-possession'
@@ -156,7 +156,7 @@ module.exports = {
     }]
   },
   'import-country': {
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     dependent: {
       field: 'import',
       value: 'yes'
@@ -178,7 +178,7 @@ module.exports = {
     includeInSummary: false
   },
   'no-storage-details': {
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     dependent: {
       field: 'stored-on-premises',
       value: 'false'
@@ -203,7 +203,7 @@ module.exports = {
       }]
   },
   'other-details': {
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     dependent: {
       field: 'usage',
       value: 'other'
@@ -268,7 +268,7 @@ module.exports = {
     }]
   },
   'weapons-unspecified-details': {
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     dependent: {
       field: 'weapons-types',
       value: 'unspecified'
@@ -397,7 +397,7 @@ module.exports = {
     }]
   },
   'ammunition-unspecified-details': {
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     dependent: {
       field: 'ammunition-types',
       value: 'unspecified'
@@ -455,22 +455,22 @@ module.exports = {
   },
   'first-authority-holders-name': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}]
   },
   'second-authority-holders-name': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}]
   },
   'first-authority-dob': date('first-authority-dob', {
     validate: ['required', 'before']
   }),
   'first-authority-town-birth': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}]
   },
   'first-authority-country-birth': {
     mixin: 'select',
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     className: ['typeahead', 'js-hidden'],
     options: [''].concat(countries)
   },
@@ -479,17 +479,17 @@ module.exports = {
   }),
   'second-authority-town-birth': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}]
   },
   'second-authority-country-birth': {
     mixin: 'select',
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     className: ['typeahead', 'js-hidden'],
     options: [''].concat(countries)
   },
   'first-authority-holders-nationality': {
     mixin: 'select',
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     className: ['typeahead', 'js-hidden'],
     options: [''].concat(countries)
   },
@@ -509,17 +509,17 @@ module.exports = {
   },
   'first-authority-holders-postcode': {
     mixin: 'input-text-code',
-    validate: ['required', 'postcode'],
+    validate: ['required', 'postcode', {'type': 'maxlength', 'arguments': [200]}],
     formatter: 'uppercase',
     includeInSummary: false
   },
   'first-authority-holders-address-lookup': {
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     className: 'address'
   },
   'first-authority-holders-address-manual': {
     mixin: 'textarea',
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [15000]}],
     'ignore-defaults': true,
     formatter: ['trim', 'hyphens'],
     attributes: [{
@@ -530,7 +530,7 @@ module.exports = {
   },
   'second-authority-holders-nationality': {
     mixin: 'select',
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     className: ['typeahead', 'js-hidden'],
     options: [''].concat(countries)
   },
@@ -550,17 +550,17 @@ module.exports = {
   },
   'second-authority-holders-postcode': {
     mixin: 'input-text-code',
-    validate: ['required', 'postcode'],
+    validate: ['required', 'postcode', {'type': 'maxlength', 'arguments': [200]}],
     formatter: 'uppercase',
     includeInSummary: false
   },
   'second-authority-holders-address-lookup': {
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     className: 'address'
   },
   'second-authority-holders-address-manual': {
     mixin: 'textarea',
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [15000]}],
     'ignore-defaults': true,
     formatter: ['trim', 'hyphens'],
     attributes: [{
@@ -571,7 +571,7 @@ module.exports = {
   },
   'contact-holder': {
     mixin: 'radio-group',
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     legend: {
       className: 'visuallyhidden'
     },
@@ -588,7 +588,7 @@ module.exports = {
     ]
   },
   'someone-else-name': {
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     dependent: {
       field: 'contact-holder',
       value: 'other'
@@ -597,18 +597,18 @@ module.exports = {
   },
   'storage-postcode': {
     mixin: 'input-text-code',
-    validate: ['required', 'postcode'],
+    validate: ['required', 'postcode', {'type': 'maxlength', 'arguments': [200]}],
     formatter: 'uppercase',
     includeInSummary: false
   },
   'storage-address-lookup': {
     className: 'address',
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     includeInSummary: false
   },
   'storage-address-manual': {
     mixin: 'textarea',
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [15000]}],
     'ignore-defaults': true,
     formatter: ['trim', 'hyphens'],
     attributes: [{
@@ -623,11 +623,11 @@ module.exports = {
   },
   'contact-phone': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}]
   },
   'use-different-address': {
     mixin: 'radio-group',
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     options: [{
       value: 'false'
     }, {
@@ -636,12 +636,12 @@ module.exports = {
     includeInSummary: false
   },
   'authority-holder-contact-address-lookup': {
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     className: 'address'
   },
   'authority-holder-contact-address-manual': {
     mixin: 'textarea',
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [15000]}],
     'ignore-defaults': true,
     formatter: ['trim', 'hyphens'],
     attributes: [{
@@ -652,18 +652,18 @@ module.exports = {
   },
   'contact-postcode': {
     mixin: 'input-text-code',
-    validate: ['required', 'postcode'],
+    validate: ['required', 'postcode', {'type': 'maxlength', 'arguments': [200]}],
     formatter: 'uppercase',
     includeInSummary: false
   },
   'contact-address-lookup': {
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     className: 'address',
     includeInSummary: false
   },
   'contact-address-manual': {
     mixin: 'textarea',
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [15000]}],
     'ignore-defaults': true,
     formatter: ['trim', 'hyphens'],
     attributes: [{
@@ -674,7 +674,7 @@ module.exports = {
   },
   'storage-add-another-address': {
     mixin: 'radio-group',
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     includeInSummary: false,
     options: [
       'yes',
@@ -712,7 +712,7 @@ module.exports = {
     }]
   },
   'purchase-order-number': {
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     dependent: {
       field: 'purchase-order',
       value: 'Yes'
@@ -720,7 +720,7 @@ module.exports = {
   },
   'invoice-contact-name': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}]
   },
   'invoice-contact-email': {
     mixin: 'input-text',
@@ -728,127 +728,127 @@ module.exports = {
   },
   'invoice-contact-phone': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}]
   },
   'invoice-building': {
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }],
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 200 }],
     includeInSummary: false
   },
   'invoice-street': {
-    validate: ['notUrl', { type: 'maxlength', arguments: 50 }],
+    validate: ['notUrl', { type: 'maxlength', arguments: 200 }],
     labelClassName: 'visuallyhidden',
     includeInSummary: false
   },
   'invoice-townOrCity': {
     validate: ['required', 'notUrl',
       { type: 'regex', arguments: /^([^0-9]*)$/ },
-      { type: 'maxlength', arguments: 100 }
+      { type: 'maxlength', arguments: 200 }
     ],
     includeInSummary: false
   },
   'invoice-postcodeOrZIPCode': {
-    validate: ['required'],
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     formatter: ['removespaces', 'uppercase'],
     includeInSummary: false
   },
   'storage-building': {
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }]
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 200 }]
   },
   'storage-street': {
-    validate: ['notUrl', { type: 'maxlength', arguments: 50 }],
+    validate: ['notUrl', { type: 'maxlength', arguments: 200 }],
     labelClassName: 'visuallyhidden'
   },
   'storage-townOrCity': {
     validate: ['required', 'notUrl',
       { type: 'regex', arguments: /^([^0-9]*)$/ },
-      { type: 'maxlength', arguments: 100 }
+      { type: 'maxlength', arguments: 200 }
     ]
   },
   'storage-postcodeOrZIPCode': {
-    validate: ['required'],
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     formatter: ['removespaces', 'uppercase']
   },
   'first-authority-holders-building': {
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }],
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 200 }],
     includeInSummary: false
   },
   'first-authority-holders-street': {
-    validate: ['notUrl', { type: 'maxlength', arguments: 50 }],
+    validate: ['notUrl', { type: 'maxlength', arguments: 200 }],
     labelClassName: 'visuallyhidden',
     includeInSummary: false
   },
   'first-authority-holders-townOrCity': {
     validate: ['required', 'notUrl',
       { type: 'regex', arguments: /^([^0-9]*)$/ },
-      { type: 'maxlength', arguments: 100 }
+      { type: 'maxlength', arguments: 200 }
     ],
     includeInSummary: false
   },
   'first-authority-holders-postcodeOrZIPCode': {
-    validate: ['required'],
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     formatter: ['removespaces', 'uppercase'],
     includeInSummary: false
   },
   'second-authority-holders-building': {
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }],
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 200 }],
     includeInSummary: false
   },
   'second-authority-holders-street': {
-    validate: ['notUrl', { type: 'maxlength', arguments: 50 }],
+    validate: ['notUrl', { type: 'maxlength', arguments: 200 }],
     labelClassName: 'visuallyhidden',
     includeInSummary: false
   },
   'second-authority-holders-townOrCity': {
     validate: ['required', 'notUrl',
       { type: 'regex', arguments: /^([^0-9]*)$/ },
-      { type: 'maxlength', arguments: 100 }
+      { type: 'maxlength', arguments: 200 }
     ],
     includeInSummary: false
   },
   'second-authority-holders-postcodeOrZIPCode': {
-    validate: ['required'],
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     formatter: ['removespaces', 'uppercase'],
     includeInSummary: false
   },
   'authority-holder-contact-building': {
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }],
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 200 }],
     includeInSummary: false
   },
   'authority-holder-contact-street': {
-    validate: ['notUrl', { type: 'maxlength', arguments: 50 }],
+    validate: ['notUrl', { type: 'maxlength', arguments: 200 }],
     labelClassName: 'visuallyhidden',
     includeInSummary: false
   },
   'authority-holder-contact-townOrCity': {
     validate: ['required', 'notUrl',
       { type: 'regex', arguments: /^([^0-9]*)$/ },
-      { type: 'maxlength', arguments: 100 }
+      { type: 'maxlength', arguments: 200 }
     ],
     includeInSummary: false
   },
   'authority-holder-contact-postcodeOrZIPCode': {
-    validate: ['required'],
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     formatter: ['removespaces', 'uppercase'],
     includeInSummary: false
   },
   'contact-building': {
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }],
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 200 }],
     includeInSummary: false
   },
   'contact-street': {
-    validate: ['notUrl', { type: 'maxlength', arguments: 50 }],
+    validate: ['notUrl', { type: 'maxlength', arguments: 200 }],
     labelClassName: 'visuallyhidden',
     includeInSummary: false
   },
   'contact-townOrCity': {
     validate: ['required', 'notUrl',
       { type: 'regex', arguments: /^([^0-9]*)$/ },
-      { type: 'maxlength', arguments: 100 }
+      { type: 'maxlength', arguments: 200 }
     ],
     includeInSummary: false
   },
   'contact-postcodeOrZIPCode': {
-    validate: ['required'],
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     formatter: ['removespaces', 'uppercase'],
     includeInSummary: false
   }

--- a/apps/new-dealer/fields/index.js
+++ b/apps/new-dealer/fields/index.js
@@ -178,7 +178,7 @@ module.exports = {
     includeInSummary: false
   },
   'no-storage-details': {
-    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
+    validate: ['required', {'type': 'maxlength', 'arguments': [15000]}],
     dependent: {
       field: 'stored-on-premises',
       value: 'false'

--- a/apps/shooting-clubs/fields/index.js
+++ b/apps/shooting-clubs/fields/index.js
@@ -15,11 +15,11 @@ module.exports = {
   },
   'club-name': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}]
   },
   'second-contact-name': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}]
   },
   'second-contact-email': {
     mixin: 'input-text',
@@ -27,26 +27,26 @@ module.exports = {
   },
   'second-contact-phone': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}]
   },
   'club-secretary-name': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}]
   },
   'club-postcode': {
     mixin: 'input-text-code',
-    validate: ['required', 'postcode'],
+    validate: ['required', 'postcode', {'type': 'maxlength', 'arguments': [200]}],
     formatter: 'uppercase',
     includeInSummary: false
   },
   'club-address-lookup': {
     className: 'address',
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     includeInSummary: false
   },
   'club-address-manual': {
     mixin: 'textarea',
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [15000]}],
     'ignore-defaults': true,
     formatter: ['trim', 'hyphens'],
     attributes: [{
@@ -56,18 +56,18 @@ module.exports = {
   },
   'club-secretary-postcode': {
     mixin: 'input-text-code',
-    validate: ['required', 'postcode'],
+    validate: ['required', 'postcode', {'type': 'maxlength', 'arguments': [200]}],
     formatter: 'uppercase',
     includeInSummary: false
   },
   'club-secretary-address-lookup': {
     className: 'address',
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     includeInSummary: false
   },
   'club-secretary-address-manual': {
     mixin: 'textarea',
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [15000]}],
     'ignore-defaults': true,
     formatter: ['trim', 'hyphens'],
     attributes: [{
@@ -81,22 +81,22 @@ module.exports = {
   },
   'club-secretary-phone': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}]
   },
   'second-contact-postcode': {
     mixin: 'input-text-code',
-    validate: ['required', 'postcode'],
+    validate: ['required', 'postcode', {'type': 'maxlength', 'arguments': [200]}],
     formatter: 'uppercase',
     includeInSummary: false
   },
   'second-contact-address-lookup': {
     className: 'address',
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     includeInSummary: false
   },
   'second-contact-address-manual': {
     mixin: 'textarea',
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [15000]}],
     'ignore-defaults': true,
     formatter: ['trim', 'hyphens'],
     attributes: [{
@@ -106,13 +106,13 @@ module.exports = {
   },
   'location-postcode': {
     mixin: 'input-text-code',
-    validate: ['required', 'postcode'],
+    validate: ['required', 'postcode', {'type': 'maxlength', 'arguments': [200]}],
     formatter: 'uppercase',
     includeInSummary: false
   },
   'location-address-manual': {
     mixin: 'textarea',
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [15000]}],
     'ignore-defaults': true,
     formatter: ['trim', 'hyphens'],
     attributes: [{
@@ -121,7 +121,7 @@ module.exports = {
     }]
   },
   'location-address-lookup': {
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     className: 'address'
   },
   'location-add-another-address': {
@@ -169,7 +169,7 @@ module.exports = {
     }]
   },
   'purchase-order-number': {
-    validate: 'required',
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     dependent: {
       field: 'purchase-order',
       value: 'Yes'
@@ -177,7 +177,7 @@ module.exports = {
   },
   'invoice-contact-name': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}]
   },
   'invoice-contact-email': {
     mixin: 'input-text',
@@ -185,108 +185,108 @@ module.exports = {
   },
   'invoice-contact-phone': {
     mixin: 'input-text',
-    validate: 'required'
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}]
   },
   'invoice-building': {
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }]
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 200 }]
   },
   'invoice-street': {
-    validate: ['notUrl', { type: 'maxlength', arguments: 50 }],
+    validate: ['notUrl', { type: 'maxlength', arguments: 200 }],
     labelClassName: 'visuallyhidden'
   },
   'invoice-townOrCity': {
     validate: ['required', 'notUrl',
       { type: 'regex', arguments: /^([^0-9]*)$/ },
-      { type: 'maxlength', arguments: 100 }
+      { type: 'maxlength', arguments: 200 }
     ]
   },
   'invoice-postcodeOrZIPCode': {
     validate: ['required'],
-    formatter: ['removespaces', 'uppercase']
+    formatter: ['removespaces', 'uppercase', {'type': 'maxlength', 'arguments': [200]}]
   },
   'club-building': {
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }]
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 200 }]
   },
   'club-street': {
-    validate: ['notUrl', { type: 'maxlength', arguments: 50 }],
+    validate: ['notUrl', { type: 'maxlength', arguments: 200 }],
     labelClassName: 'visuallyhidden'
   },
   'club-townOrCity': {
     validate: ['required', 'notUrl',
       { type: 'regex', arguments: /^([^0-9]*)$/ },
-      { type: 'maxlength', arguments: 100 }
+      { type: 'maxlength', arguments: 200 }
     ]
   },
   'club-postcodeOrZIPCode': {
-    validate: ['required'],
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     formatter: ['removespaces', 'uppercase']
   },
   'club-secretary-building': {
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }]
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 200 }]
   },
   'club-secretary-street': {
-    validate: ['notUrl', { type: 'maxlength', arguments: 50 }],
+    validate: ['notUrl', { type: 'maxlength', arguments: 200 }],
     labelClassName: 'visuallyhidden'
   },
   'club-secretary-townOrCity': {
     validate: ['required', 'notUrl',
       { type: 'regex', arguments: /^([^0-9]*)$/ },
-      { type: 'maxlength', arguments: 100 }
+      { type: 'maxlength', arguments: 200 }
     ]
   },
   'club-secretary-postcodeOrZIPCode': {
     validate: ['required'],
-    formatter: ['removespaces', 'uppercase']
+    formatter: ['removespaces', 'uppercase', {'type': 'maxlength', 'arguments': [200]}]
   },
   'second-contact-building': {
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }]
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 200 }]
   },
   'second-contact-street': {
-    validate: ['notUrl', { type: 'maxlength', arguments: 50 }],
+    validate: ['notUrl', { type: 'maxlength', arguments: 200 }],
     labelClassName: 'visuallyhidden'
   },
   'second-contact-townOrCity': {
     validate: ['required', 'notUrl',
       { type: 'regex', arguments: /^([^0-9]*)$/ },
-      { type: 'maxlength', arguments: 100 }
+      { type: 'maxlength', arguments: 200 }
     ]
   },
   'second-contact-postcodeOrZIPCode': {
     validate: ['required'],
-    formatter: ['removespaces', 'uppercase']
+    formatter: ['removespaces', 'uppercase', {'type': 'maxlength', 'arguments': [200]}]
   },
   'location-building': {
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }]
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 200 }]
   },
   'location-street': {
-    validate: ['notUrl', { type: 'maxlength', arguments: 50 }],
+    validate: ['notUrl', { type: 'maxlength', arguments: 200 }],
     labelClassName: 'visuallyhidden'
   },
   'location-townOrCity': {
     validate: ['required', 'notUrl',
       { type: 'regex', arguments: /^([^0-9]*)$/ },
-      { type: 'maxlength', arguments: 100 }
+      { type: 'maxlength', arguments: 200 }
     ]
   },
   'location-postcodeOrZIPCode': {
     validate: ['required'],
-    formatter: ['removespaces', 'uppercase']
+    formatter: ['removespaces', 'uppercase', {'type': 'maxlength', 'arguments': [200]}]
   },
   'storage-building': {
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 100 }]
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 200 }]
   },
   'storage-street': {
-    validate: ['notUrl', { type: 'maxlength', arguments: 50 }],
+    validate: ['notUrl', { type: 'maxlength', arguments: 200 }],
     labelClassName: 'visuallyhidden'
   },
   'storage-townOrCity': {
     validate: ['required', 'notUrl',
       { type: 'regex', arguments: /^([^0-9]*)$/ },
-      { type: 'maxlength', arguments: 100 }
+      { type: 'maxlength', arguments: 200 }
     ]
   },
   'storage-postcodeOrZIPCode': {
     validate: ['required'],
-    formatter: ['removespaces', 'uppercase']
+    formatter: ['removespaces', 'uppercase', {'type': 'maxlength', 'arguments': [200]}]
   }
 };

--- a/apps/supporting-documents/fields/index.js
+++ b/apps/supporting-documents/fields/index.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   'reference-number': {
-    validate: ['required'],
+    validate: ['required', {'type': 'maxlength', 'arguments': [200]}],
     invalidates: ['email']
   },
   email: {


### PR DESCRIPTION
What?
Added additional validation rules to all input-text fields through-out application

Why?
Because large amounts of data cause UI issues and should not be accepted

How?
We have added new maxlength rules for all text inputs. 320 for emails, 15000 for text areas and 200 for all other text inputs.

Testing?
Tested locally

Screenshots (optional)
Anything Else?