### PR TITLE
Added new root page and relevant navigation

### DIFF
--- a/apps/common/fields/index.js
+++ b/apps/common/fields/index.js
@@ -1,6 +1,19 @@
 'use strict';
 
 module.exports = {
+  'choose-a-journey': {
+    mixin: 'radio-group',
+    validate: 'required',
+    options: [
+      'museums',
+      'new-dealer',
+      'shooting-clubs',
+      'supporting-documents'
+    ],
+    legend: {
+      className: 'visuallyhidden'
+    }
+  },
   activity: {
     mixin: 'radio-group',
     validate: 'required',

--- a/apps/common/index.js
+++ b/apps/common/index.js
@@ -8,6 +8,45 @@ module.exports = {
     '/cookies': 'cookies'
   },
   steps: {
+    '/choose': {
+      fields: [
+        'choose-a-journey'
+      ],
+      locals: {
+        section: 'choose-a-journey'
+      },
+      forks: [
+        {
+          target: '/museums',
+          condition: {
+            field: 'choose-a-journey',
+            value: 'museums'
+          }
+        },
+        {
+          target: '/s5',
+          condition: {
+            field: 'choose-a-journey',
+            value: 'new-dealer'
+          }
+        },
+        {
+          target: '/supporting-documents',
+          condition: {
+            field: 'choose-a-journey',
+            value: 'supporting-documents'
+          }
+        },
+        {
+          target: '/shooting-clubs',
+          condition: {
+            field: 'choose-a-journey',
+            value: 'shooting-clubs'
+          }
+        }
+      ],
+      next: '/privacy'
+    },
     '/privacy': {},
     '/accessibility': {},
     '/cookies': {}

--- a/apps/common/translations/src/en/fields.json
+++ b/apps/common/translations/src/en/fields.json
@@ -1,4 +1,20 @@
 {
+  "choose-a-journey": {
+    "options": {
+      "museums": {
+        "label": "Museums"
+      },
+      "new-dealer": {
+        "label": "New Dealer"
+      },
+      "shooting-clubs": {
+        "label": "Shooting Clubs"
+      },
+      "supporting-documents": {
+        "label": "Supporting Documents"
+      }
+    }
+  },
   "activity": {
     "options": {
       "new": {

--- a/apps/common/translations/src/en/journey.json
+++ b/apps/common/translations/src/en/journey.json
@@ -1,0 +1,3 @@
+{
+  "header": "Choose A Journey"
+}

--- a/apps/common/translations/src/en/pages.json
+++ b/apps/common/translations/src/en/pages.json
@@ -1,4 +1,7 @@
 {
+  "choose": {
+    "header": "Choose A Journey"
+  },
   "privacy": {
     "header": "Privacy Notice"
   },

--- a/apps/common/translations/src/en/validation.json
+++ b/apps/common/translations/src/en/validation.json
@@ -1,4 +1,7 @@
 {
+  "choose-a-journey": {
+    "required": "Select an option"
+  },
   "activity": {
     "required": "Select an option"
   },

--- a/apps/common/views/choose.html
+++ b/apps/common/views/choose.html
@@ -1,0 +1,8 @@
+{{<partials-page}}
+  {{$page-content}}
+    {{#fields}}
+      {{#renderField}}{{/renderField}}
+    {{/fields}}
+    {{#input-submit}}continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}


### PR DESCRIPTION
What?
No root page exists meaning locals fail to load. This results in a 500 error in production when you click Continue on the root privacy page. We have now added a root page with 4 options so the user can choose their journey.

Why?
This gives a better user experience and less likely to experience unwanted journeys.

How?
Added a choose-a-journey radio field and the appropriate forking.

Testing?
Tested manually.

Screenshots (optional)
Anything Else?