### PR TITLE
FIREARMS-64-Removed root privacy journey

### DIFF
--- a/apps/common/index.js
+++ b/apps/common/index.js
@@ -3,7 +3,6 @@
 module.exports = {
   name: 'common',
   pages: {
-    '/privacy': 'privacy',
     '/accessibility': 'accessibility',
     '/cookies': 'cookies'
   },


### PR DESCRIPTION
What?

With the new root page, we no longer require the privacy page and so this route should be removed.

How?

Removed from the journey schema

Testing?
Tested locally

Screenshots?
N/A