### PR TITLE
FIREARMS-3 Removed required on all phone number fields

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -36,4 +36,8 @@ ignore:
     - hof > browserify > module-deps > detective > minimist:
         reason: Need to update browserify in HOF when new version is available.
         expires: '2022-09-18T14:58:46.388Z'
+  SNYK-JS-DICER-2311764:
+    - busboy-body-parser > busboy > dicer:
+        reason: Will require replacement of busboy-body-parser
+        expires: '2022-07-07T15:04:29.410Z'
 patch: {}

--- a/apps/museums/fields/index.js
+++ b/apps/museums/fields/index.js
@@ -15,7 +15,7 @@ module.exports = {
   },
   'contact-phone': {
     mixin: 'input-text',
-    validate: ['required', 'internationalPhoneNumber', {type: 'maxlength', arguments: [200]}]
+    validate: ['internationalPhoneNumber', {type: 'maxlength', arguments: [200]}]
   },
   'same-contact-address': {
     mixin: 'radio-group',
@@ -66,7 +66,7 @@ module.exports = {
   },
   'invoice-contact-phone': {
     mixin: 'input-text',
-    validate: ['required', 'internationalPhoneNumber', {type: 'maxlength', arguments: [200]}]
+    validate: ['internationalPhoneNumber', {type: 'maxlength', arguments: [200]}]
   },
   'exhibit-building': {
     validate: ['required', 'notUrl', { type: 'maxlength', arguments: 200 }]

--- a/apps/new-dealer/fields/index.js
+++ b/apps/new-dealer/fields/index.js
@@ -623,7 +623,7 @@ module.exports = {
   },
   'contact-phone': {
     mixin: 'input-text',
-    validate: ['required', 'internationalPhoneNumber', {type: 'maxlength', arguments: [200]}]
+    validate: ['internationalPhoneNumber', {type: 'maxlength', arguments: [200]}]
   },
   'use-different-address': {
     mixin: 'radio-group',
@@ -728,7 +728,7 @@ module.exports = {
   },
   'invoice-contact-phone': {
     mixin: 'input-text',
-    validate: ['required', 'internationalPhoneNumber', {type: 'maxlength', arguments: [200]}]
+    validate: ['internationalPhoneNumber', {type: 'maxlength', arguments: [200]}]
   },
   'invoice-building': {
     validate: ['required', 'notUrl', { type: 'maxlength', arguments: 200 }],

--- a/apps/shooting-clubs/fields/index.js
+++ b/apps/shooting-clubs/fields/index.js
@@ -27,7 +27,7 @@ module.exports = {
   },
   'second-contact-phone': {
     mixin: 'input-text',
-    validate: ['required', 'internationalPhoneNumber', {type: 'maxlength', arguments: [200]}]
+    validate: ['internationalPhoneNumber', {type: 'maxlength', arguments: [200]}]
   },
   'club-secretary-name': {
     mixin: 'input-text',
@@ -81,7 +81,7 @@ module.exports = {
   },
   'club-secretary-phone': {
     mixin: 'input-text',
-    validate: ['required', 'internationalPhoneNumber', {type: 'maxlength', arguments: [200]}]
+    validate: ['internationalPhoneNumber', {type: 'maxlength', arguments: [200]}]
   },
   'second-contact-postcode': {
     mixin: 'input-text-code',
@@ -185,7 +185,7 @@ module.exports = {
   },
   'invoice-contact-phone': {
     mixin: 'input-text',
-    validate: ['required', 'internationalPhoneNumber', {type: 'maxlength', arguments: [200]}]
+    validate: ['internationalPhoneNumber', {type: 'maxlength', arguments: [200]}]
   },
   'invoice-building': {
     validate: ['required', 'notUrl', { type: 'maxlength', arguments: 200 }]

--- a/test/_features/firearms/museums.feature
+++ b/test/_features/firearms/museums.feature
@@ -355,7 +355,6 @@ Feature: Firearms application for a Museum
         Then I should be on the 'contact-details' page showing 'What are their contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter a contact email address' error
-        Then I should see the 'Enter a contact phone number' error
 
     Scenario: I am on the Museums journey and don't select an option on the contact-address page
         Given I start the 'museums' application journey
@@ -453,7 +452,6 @@ Feature: Firearms application for a Museum
         Then I select 'Continue'
         Then I should see the 'Enter a contact name' error
         Then I should see the 'Enter a contact email address' error
-        Then I should see the 'Enter a contact phone number' error
     
     Scenario: I am on the Museums journey and don't fill in the address on the invoice-address-input page
         Given I start the 'museums' application journey

--- a/test/_features/firearms/new-dealer.feature
+++ b/test/_features/firearms/new-dealer.feature
@@ -1259,7 +1259,6 @@ Feature: Firearms application for a New-dealer
         Then I should be on the 'contact-details' page showing 'What are Donald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter contact\'s email address' error
-        Then I should see the 'Enter contact\'s phone number' error
 
     Scenario: I am on the New-dealer journey but don't select an option on the authority-holder-contact-postcode page
         Given I start the 's5' application journey
@@ -1361,7 +1360,6 @@ Feature: Firearms application for a New-dealer
         Then I should be on the 'contact-details' page showing 'What are Donald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter contact\'s email address' error
-        Then I should see the 'Enter contact\'s phone number' error
         Then I fill 'contact-email' with 'test@test.com'
         Then I fill 'contact-phone' with '01234567891'
         Then I select 'Continue'
@@ -1469,7 +1467,6 @@ Feature: Firearms application for a New-dealer
         Then I should be on the 'contact-details' page showing 'What are Donald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter contact\'s email address' error
-        Then I should see the 'Enter contact\'s phone number' error
         Then I fill 'contact-email' with 'test@test.com'
         Then I fill 'contact-phone' with '01234567891'
         Then I select 'Continue'
@@ -1482,7 +1479,6 @@ Feature: Firearms application for a New-dealer
         Then I select 'Continue'
         Then I should see the 'Enter a contact name' error
         Then I should see the 'Enter a contact email address' error
-        Then I should see the 'Enter a contact phone number' error
 
     Scenario: I am on the New-dealer journey but don't fill in invoice address on the invoice-address-input page
         Given I start the 's5' application journey
@@ -1584,7 +1580,6 @@ Feature: Firearms application for a New-dealer
         Then I should be on the 'contact-details' page showing 'What are Donald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter contact\'s email address' error
-        Then I should see the 'Enter contact\'s phone number' error
         Then I fill 'contact-email' with 'test@test.com'
         Then I fill 'contact-phone' with '01234567891'
         Then I select 'Continue'
@@ -1597,7 +1592,6 @@ Feature: Firearms application for a New-dealer
         Then I select 'Continue'
         Then I should see the 'Enter a contact name' error
         Then I should see the 'Enter a contact email address' error
-        Then I should see the 'Enter a contact phone number' error
         Then I fill 'invoice-contact-name' with 'Bonnie testman'
         Then I fill 'invoice-contact-email' with 'test@test.com'
         Then I fill 'invoice-contact-phone' with '01234567891'
@@ -1708,7 +1702,6 @@ Feature: Firearms application for a New-dealer
         Then I should be on the 'contact-details' page showing 'What are Donald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter contact\'s email address' error
-        Then I should see the 'Enter contact\'s phone number' error
         Then I fill 'contact-email' with 'test@test.com'
         Then I fill 'contact-phone' with '01234567891'
         Then I select 'Continue'
@@ -1721,7 +1714,6 @@ Feature: Firearms application for a New-dealer
         Then I select 'Continue'
         Then I should see the 'Enter a contact name' error
         Then I should see the 'Enter a contact email address' error
-        Then I should see the 'Enter a contact phone number' error
         Then I fill 'invoice-contact-name' with 'Bonnie testman'
         Then I fill 'invoice-contact-email' with 'test@test.com'
         Then I fill 'invoice-contact-phone' with '01234567891'
@@ -1840,7 +1832,6 @@ Feature: Firearms application for a New-dealer
         Then I should be on the 'contact-details' page showing 'What are Donald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter contact\'s email address' error
-        Then I should see the 'Enter contact\'s phone number' error
         Then I fill 'contact-email' with 'test@test.com'
         Then I fill 'contact-phone' with '01234567891'
         Then I select 'Continue'
@@ -1853,7 +1844,6 @@ Feature: Firearms application for a New-dealer
         Then I select 'Continue'
         Then I should see the 'Enter a contact name' error
         Then I should see the 'Enter a contact email address' error
-        Then I should see the 'Enter a contact phone number' error
         Then I fill 'invoice-contact-name' with 'Bonnie testman'
         Then I fill 'invoice-contact-email' with 'test@test.com'
         Then I fill 'invoice-contact-phone' with '01234567891'

--- a/test/_features/firearms/shooting-clubs.feature
+++ b/test/_features/firearms/shooting-clubs.feature
@@ -185,7 +185,6 @@ Feature: Fireams application for Shooting clubs
         Then I should be on the 'club-secretary-email' page showing 'What are Ronald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter the club secretary\'s email' error
-        Then I should see the 'Enter the club secretary\'s phone number' error
 
     Scenario: I am on the Shooting-clubs journey but I don't fill in contact details on the club-secretary-email page
         Given I start the 'shooting-clubs' application journey
@@ -234,7 +233,6 @@ Feature: Fireams application for Shooting clubs
         Then I should be on the 'club-secretary-email' page showing 'What are Ronald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter the club secretary\'s email' error
-        Then I should see the 'Enter the club secretary\'s phone number' error
 
     Scenario: I am on the Shooting-clubs journey but I don't fill in the name on the second-contact-name page
         Given I start the 'shooting-clubs' application journey
@@ -283,7 +281,6 @@ Feature: Fireams application for Shooting clubs
         Then I should be on the 'club-secretary-email' page showing 'What are Ronald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter the club secretary\'s email' error
-        Then I should see the 'Enter the club secretary\'s phone number' error
         Then I fill 'club-secretary-email' with 'test@test.com'
         Then I fill 'club-secretary-phone' with '01234567891'
         Then I select 'Continue'
@@ -338,7 +335,6 @@ Feature: Fireams application for Shooting clubs
         Then I should be on the 'club-secretary-email' page showing 'What are Ronald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter the club secretary\'s email' error
-        Then I should see the 'Enter the club secretary\'s phone number' error
         Then I fill 'club-secretary-email' with 'test@test.com'
         Then I fill 'club-secretary-phone' with '01234567891'
         Then I select 'Continue'
@@ -400,7 +396,6 @@ Feature: Fireams application for Shooting clubs
         Then I should be on the 'club-secretary-email' page showing 'What are Ronald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter the club secretary\'s email' error
-        Then I should see the 'Enter the club secretary\'s phone number' error
         Then I fill 'club-secretary-email' with 'test@test.com'
         Then I fill 'club-secretary-phone' with '01234567891'
         Then I select 'Continue'
@@ -422,7 +417,6 @@ Feature: Fireams application for Shooting clubs
         Then I should be on the 'second-contact-email' page showing 'What are Ronald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter the second person\'s email' error
-        Then I should see the 'Enter the second person\'s phone number' error
 
     Scenario: I am on the Shooting-clubs journey but I don't fill in the address on the location-address page
         Given I start the 'shooting-clubs' application journey
@@ -471,7 +465,6 @@ Feature: Fireams application for Shooting clubs
         Then I should be on the 'club-secretary-email' page showing 'What are Ronald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter the club secretary\'s email' error
-        Then I should see the 'Enter the club secretary\'s phone number' error
         Then I fill 'club-secretary-email' with 'test@test.com'
         Then I fill 'club-secretary-phone' with '01234567891'
         Then I select 'Continue'
@@ -493,7 +486,6 @@ Feature: Fireams application for Shooting clubs
         Then I should be on the 'second-contact-email' page showing 'What are Ronald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter the second person\'s email' error
-        Then I should see the 'Enter the second person\'s phone number' error
         Then I fill 'second-contact-email' with 'test@test.com'
         Then I fill 'second-contact-phone' with '01234567891'
         Then I select 'Continue'
@@ -550,7 +542,6 @@ Feature: Fireams application for Shooting clubs
         Then I should be on the 'club-secretary-email' page showing 'What are Ronald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter the club secretary\'s email' error
-        Then I should see the 'Enter the club secretary\'s phone number' error
         Then I fill 'club-secretary-email' with 'test@test.com'
         Then I fill 'club-secretary-phone' with '01234567891'
         Then I select 'Continue'
@@ -572,7 +563,6 @@ Feature: Fireams application for Shooting clubs
         Then I should be on the 'second-contact-email' page showing 'What are Ronald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter the second person\'s email' error
-        Then I should see the 'Enter the second person\'s phone number' error
         Then I fill 'second-contact-email' with 'test@test.com'
         Then I fill 'second-contact-phone' with '01234567891'
         Then I select 'Continue'
@@ -639,7 +629,6 @@ Feature: Fireams application for Shooting clubs
         Then I should be on the 'club-secretary-email' page showing 'What are Ronald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter the club secretary\'s email' error
-        Then I should see the 'Enter the club secretary\'s phone number' error
         Then I fill 'club-secretary-email' with 'test@test.com'
         Then I fill 'club-secretary-phone' with '01234567891'
         Then I select 'Continue'
@@ -661,7 +650,6 @@ Feature: Fireams application for Shooting clubs
         Then I should be on the 'second-contact-email' page showing 'What are Ronald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter the second person\'s email' error
-        Then I should see the 'Enter the second person\'s phone number' error
         Then I fill 'second-contact-email' with 'test@test.com'
         Then I fill 'second-contact-phone' with '01234567891'
         Then I select 'Continue'
@@ -731,7 +719,6 @@ Feature: Fireams application for Shooting clubs
         Then I should be on the 'club-secretary-email' page showing 'What are Ronald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter the club secretary\'s email' error
-        Then I should see the 'Enter the club secretary\'s phone number' error
         Then I fill 'club-secretary-email' with 'test@test.com'
         Then I fill 'club-secretary-phone' with '01234567891'
         Then I select 'Continue'
@@ -753,7 +740,6 @@ Feature: Fireams application for Shooting clubs
         Then I should be on the 'second-contact-email' page showing 'What are Ronald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter the second person\'s email' error
-        Then I should see the 'Enter the second person\'s phone number' error
         Then I fill 'second-contact-email' with 'test@test.com'
         Then I fill 'second-contact-phone' with '01234567891'
         Then I select 'Continue'
@@ -828,7 +814,6 @@ Feature: Fireams application for Shooting clubs
         Then I should be on the 'club-secretary-email' page showing 'What are Ronald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter the club secretary\'s email' error
-        Then I should see the 'Enter the club secretary\'s phone number' error
         Then I fill 'club-secretary-email' with 'test@test.com'
         Then I fill 'club-secretary-phone' with '01234567891'
         Then I select 'Continue'
@@ -850,7 +835,6 @@ Feature: Fireams application for Shooting clubs
         Then I should be on the 'second-contact-email' page showing 'What are Ronald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter the second person\'s email' error
-        Then I should see the 'Enter the second person\'s phone number' error
         Then I fill 'second-contact-email' with 'test@test.com'
         Then I fill 'second-contact-phone' with '01234567891'
         Then I select 'Continue'
@@ -928,7 +912,6 @@ Feature: Fireams application for Shooting clubs
         Then I should be on the 'club-secretary-email' page showing 'What are Ronald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter the club secretary\'s email' error
-        Then I should see the 'Enter the club secretary\'s phone number' error
         Then I fill 'club-secretary-email' with 'test@test.com'
         Then I fill 'club-secretary-phone' with '01234567891'
         Then I select 'Continue'
@@ -950,7 +933,6 @@ Feature: Fireams application for Shooting clubs
         Then I should be on the 'second-contact-email' page showing 'What are Ronald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter the second person\'s email' error
-        Then I should see the 'Enter the second person\'s phone number' error
         Then I fill 'second-contact-email' with 'test@test.com'
         Then I fill 'second-contact-phone' with '01234567891'
         Then I select 'Continue'
@@ -984,7 +966,6 @@ Feature: Fireams application for Shooting clubs
         Then I select 'Continue'
         Then I should see the 'Enter a contact name' error
         Then I should see the 'Enter a contact email address' error
-        Then I should see the 'Enter a contact phone number' error
 
     Scenario: I am on the Shooting-clubs journey but I don't fill in the address on the invoice-address-input page
         Given I start the 'shooting-clubs' application journey
@@ -1033,7 +1014,6 @@ Feature: Fireams application for Shooting clubs
         Then I should be on the 'club-secretary-email' page showing 'What are Ronald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter the club secretary\'s email' error
-        Then I should see the 'Enter the club secretary\'s phone number' error
         Then I fill 'club-secretary-email' with 'test@test.com'
         Then I fill 'club-secretary-phone' with '01234567891'
         Then I select 'Continue'
@@ -1055,7 +1035,6 @@ Feature: Fireams application for Shooting clubs
         Then I should be on the 'second-contact-email' page showing 'What are Ronald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter the second person\'s email' error
-        Then I should see the 'Enter the second person\'s phone number' error
         Then I fill 'second-contact-email' with 'test@test.com'
         Then I fill 'second-contact-phone' with '01234567891'
         Then I select 'Continue'
@@ -1089,7 +1068,6 @@ Feature: Fireams application for Shooting clubs
         Then I select 'Continue'
         Then I should see the 'Enter a contact name' error
         Then I should see the 'Enter a contact email address' error
-        Then I should see the 'Enter a contact phone number' error
         Then I fill 'invoice-contact-name' with 'Bonnie Testman'
         Then I fill 'invoice-contact-email' with 'bonnie@testman.com'
         Then I fill 'invoice-contact-phone' with '01234567898'
@@ -1147,7 +1125,6 @@ Feature: Fireams application for Shooting clubs
         Then I should be on the 'club-secretary-email' page showing 'What are Ronald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter the club secretary\'s email' error
-        Then I should see the 'Enter the club secretary\'s phone number' error
         Then I fill 'club-secretary-email' with 'test@test.com'
         Then I fill 'club-secretary-phone' with '01234567891'
         Then I select 'Continue'
@@ -1169,7 +1146,6 @@ Feature: Fireams application for Shooting clubs
         Then I should be on the 'second-contact-email' page showing 'What are Ronald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter the second person\'s email' error
-        Then I should see the 'Enter the second person\'s phone number' error
         Then I fill 'second-contact-email' with 'test@test.com'
         Then I fill 'second-contact-phone' with '01234567891'
         Then I select 'Continue'
@@ -1203,7 +1179,6 @@ Feature: Fireams application for Shooting clubs
         Then I select 'Continue'
         Then I should see the 'Enter a contact name' error
         Then I should see the 'Enter a contact email address' error
-        Then I should see the 'Enter a contact phone number' error
         Then I fill 'invoice-contact-name' with 'Bonnie Testman'
         Then I fill 'invoice-contact-email' with 'bonnie@testman.com'
         Then I fill 'invoice-contact-phone' with '01234567898'
@@ -1269,7 +1244,6 @@ Feature: Fireams application for Shooting clubs
         Then I should be on the 'club-secretary-email' page showing 'What are Ronald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter the club secretary\'s email' error
-        Then I should see the 'Enter the club secretary\'s phone number' error
         Then I fill 'club-secretary-email' with 'test@test.com'
         Then I fill 'club-secretary-phone' with '01234567891'
         Then I select 'Continue'
@@ -1291,7 +1265,6 @@ Feature: Fireams application for Shooting clubs
         Then I should be on the 'second-contact-email' page showing 'What are Ronald Testman\'s contact details?'
         Then I select 'Continue'
         Then I should see the 'Enter the second person\'s email' error
-        Then I should see the 'Enter the second person\'s phone number' error
         Then I fill 'second-contact-email' with 'test@test.com'
         Then I fill 'second-contact-phone' with '01234567891'
         Then I select 'Continue'
@@ -1325,7 +1298,6 @@ Feature: Fireams application for Shooting clubs
         Then I select 'Continue'
         Then I should see the 'Enter a contact name' error
         Then I should see the 'Enter a contact email address' error
-        Then I should see the 'Enter a contact phone number' error
         Then I fill 'invoice-contact-name' with 'Bonnie Testman'
         Then I fill 'invoice-contact-email' with 'bonnie@testman.com'
         Then I fill 'invoice-contact-phone' with '01234567898'


### PR DESCRIPTION
What?
As per conversation with the business, to prevent possible over zealous international phone number validation introduced in a previous commit, we should allow phone number fields to be blank.

How?
Removed the required attribute from all phone number fields.

Testing?
Tested locally

Screenshots?
N/A