### PR TITLE
FIREARMS-126: NODE_ENV changed for UAT acceptance tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -273,6 +273,7 @@ steps:
   - name: test_acceptance_uat
     <<: *acceptance_tests
     commands:
+      - export NODE_ENV=development
       - export ACCEPTANCE_HOST_NAME=https://dev.notprod.$${APP_NAME}.homeoffice.gov.uk
       - npx playwright install
       - npm run test:acceptance


### PR DESCRIPTION
**Changes**

- NODE_ENV added for uat acceptance tests in drone.yaml file, to mitigate errors in acceptance test due to wrong environment