### PR TITLE
FIREARMS-112: add new CSP rules to service config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Firearms Licensing Application
 ------------------------------
-Firearms Licensing Application built using HOF (Home Office Forms) framework.
+Firearms Licensing Application built using HOF (Home Office Forms) framework..
 
 
 ## Getting Started

--- a/server.js
+++ b/server.js
@@ -23,7 +23,17 @@ settings = Object.assign({}, settings, {
     }
   }, require('hof/components/clear-session')
   ],
-  redis: config.redis
+  redis: config.redis,
+  imgSrc: [
+    'www.google-analytics.com',
+    'ssl.gstatic.com',
+    'www.google.co.uk/ads/ga-audiences'
+  ],
+  connectSrc: [
+    'https://www.google-analytics.com',
+    'https://region1.google-analytics.com',
+    'https://region1.analytics.google.com'
+  ]
 });
 
 const app = hof(settings);

--- a/server.js
+++ b/server.js
@@ -24,16 +24,18 @@ settings = Object.assign({}, settings, {
   }, require('hof/components/clear-session')
   ],
   redis: config.redis,
-  imgSrc: [
-    'www.google-analytics.com',
-    'ssl.gstatic.com',
-    'www.google.co.uk/ads/ga-audiences'
-  ],
-  connectSrc: [
-    'https://www.google-analytics.com',
-    'https://region1.google-analytics.com',
-    'https://region1.analytics.google.com'
-  ]
+  csp: {
+    imgSrc: [
+      'www.google-analytics.com',
+      'ssl.gstatic.com',
+      'www.google.co.uk/ads/ga-audiences'
+    ],
+    connectSrc: [
+      'https://www.google-analytics.com',
+      'https://region1.google-analytics.com',
+      'https://region1.analytics.google.com'
+    ]
+  }
 });
 
 const app = hof(settings);


### PR DESCRIPTION
## What

Add the following CSP rules to service config

imgSrc: [
      'www.google-analytics.com',
      'ssl.gstatic.com',
      'www.google.co.uk/ads/ga-audiences'
    ],
    connectSrc: [
      'https://www.google-analytics.com',
      'https://region1.google-analytics.com',
      'https://region1.analytics.google.com'
    ]

## Why

Support new GA analytics domain from https://region1.analytics.google.com to https://region1.google-analytics.com
