### PR TITLE
HOFF-794: Deploy Internal Ingress for performance testing

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -50,4 +50,24 @@ ignore:
     - busboy-body-parser > busboy > dicer:
         reason: No update available
         expires: '2024-04-10T12:21:04.350Z'
+  SNYK-JS-AXIOS-6032459:
+    - hof > notifications-node-client > axios:
+        reason: Need to update notifications-node-client in HOF to version 8.0.0.
+        expires: '2024-07-03T00:00:00.000Z'
+  SNYK-JS-AXIOS-6124857:
+    - hof > notifications-node-client > axios:
+        reason: Need to update notifications-node-client in HOF to version 8.0.0.
+        expires: '2024-07-03T00:00:00.000Z'
+  SNYK-JS-AXIOS-6144788:
+    - hof > notifications-node-client > axios:
+      reason: Need to update notifications-node-client in HOF to version 8.0.0.
+      expires: '2024-07-03T00:00:00.000Z'
+  SNYK-JS-INFLIGHT-6095116:
+    - '*':
+      reason: No update available.
+      expires: '2024-07-03T00:00:00.000Z'
+  SNYK-JS-MARKDOWNIT-6483324:
+    - hof > markdown-it:
+      reason: No update available.
+      expires: '2024-07-03T00:00:00.000Z'
 patch: {}

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -29,6 +29,7 @@ if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
 elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml  -f kube/app/service.yml
   $kd -f kube/app/ingress-external.yml -f kube/app/networkpolicy-external.yml
+  $kd -f kube/app/ingress-internal.yml
   $kd -f kube/redis -f kube/html-pdf -f kube/file-vault -f kube/app/deployment.yml
 elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml  -f kube/app/service.yml


### PR DESCRIPTION
### **WHAT?**

Testers require Internal Ingress for automation testing. UAT Environment of Firearms never had Internal Ingress. We are deploying internal ingress . We are not allowing public access to any of the URLs. We also need to set Ingress class to nginx-internal. 
https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-794

### **WHY?**

External ingress is returning 403 Forbidden error. 


### **HOW?**

Update if condition to Ingress annotations which are exported to internal ingress file in firearms repo


### **Testing?**

We can test by deploying to UAT. If we dont have admission policy in the namespace we will see the Drone build complaining about it while deploying to UAT


### **Screenshots?**


### **Anything Else?**