### PR TITLE
HOFF-794: Add internal ingress and network Policy

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -50,4 +50,24 @@ ignore:
     - busboy-body-parser > busboy > dicer:
         reason: No update available
         expires: '2024-04-10T12:21:04.350Z'
+  SNYK-JS-AXIOS-6032459:
+    - hof > notifications-node-client > axios:
+        reason: Need to update notifications-node-client in HOF to version 8.0.0.
+        expires: '2024-07-03T00:00:00.000Z'
+  SNYK-JS-AXIOS-6124857:
+    - hof > notifications-node-client > axios:
+        reason: Need to update notifications-node-client in HOF to version 8.0.0.
+        expires: '2024-07-03T00:00:00.000Z'
+  SNYK-JS-AXIOS-6144788:
+    - hof > notifications-node-client > axios:
+      reason: Need to update notifications-node-client in HOF to version 8.0.0.
+      expires: '2024-07-03T00:00:00.000Z'
+  SNYK-JS-INFLIGHT-6095116:
+    - '*':
+      reason: No update available.
+      expires: '2024-07-03T00:00:00.000Z'
+  SNYK-JS-MARKDOWNIT-6483324:
+    - hof > markdown-it:
+      reason: No update available.
+      expires: '2024-07-03T00:00:00.000Z'
 patch: {}

--- a/.snyk
+++ b/.snyk
@@ -5,69 +5,109 @@ ignore:
   SNYK-JS-REQUEST-3361831:
     - '*':
         reason: HOF framework needs updating to remove request.js
-        expires: 2024-03-01T00:00:00.000Z
-        created: 2023-08-09T13:22:47.350Z
+        expires: 2024-10-01T00:00:00.000Z
+        created: 2023-10-09T13:22:47.350Z
   SNYK-JS-TOUGHCOOKIE-5672873:
     - '*':
         reason: HOF framework needs updating to remove request.js of which this is a dependency
-        expires: 2024-03-01T00:00:00.000Z
-        created: 2023-08-09T13:22:47.350Z
+        expires: 2024-10-01T00:00:00.000Z
+        created: 2023-10-09T13:22:47.350Z
   SNYK-JS-REQUEST-1314897:
     - hof > request:
         reason: Need to replace request in HOF
-        expires: '2024-09-18T14:58:46.388Z'
+        expires: '2024-10-18T14:58:46.388Z'
   SNYK-JS-SHELLQUOTE-1766506:
     - hof > browserify > shell-quote:
         reason: Need to update browserify in HOF when new version is available.
-        expires: '2024-09-18T14:58:46.388Z'
+        expires: '2024-10-18T14:58:46.388Z'
   SNYK-JS-CACHEDPATHRELATIVE-2342653:
     - hof > browserify > cached-path-relative:
         reason: Need to update browserify in HOF when new version is available.
-        expires: '2024-09-18T14:58:46.388Z'
+        expires: '2024-10-18T14:58:46.388Z'
     - hof > browserify > module-deps > cached-path-relative:
         reason: Need to update browserify in HOF when new version is available.
-        expires: '2024-09-18T14:58:46.388Z'
+        expires: '2024-10-18T14:58:46.388Z'
   SNYK-JS-MINIMIST-2429795:
     - hof > minimist:
         reason: Need to update browserify in HOF when new version is available.
-        expires: '2024-06-01T14:58:46.388Z'
+        expires: '2024-10-01T14:58:46.388Z'
     - hof > mkdirp > minimist:
         reason: Need to update browserify in HOF when new version is available.
-        expires: '2024-06-01T14:58:46.388Z'
+        expires: '2024-10-01T14:58:46.388Z'
     - hof > browserify > subarg > minimist:
         reason: Need to update browserify in HOF when new version is available.
-        expires: '2024-06-01T14:58:46.388Z'
+        expires: '2024-10-01T14:58:46.388Z'
     - hof > browserify > deps-sort > subarg > minimist:
         reason: Need to update browserify in HOF when new version is available.
-        expires: '2024-06-01T14:58:46.388Z'
+        expires: '2024-10-01T14:58:46.388Z'
     - hof > browserify > module-deps > subarg > minimist:
         reason: Need to update browserify in HOF when new version is available.
-        expires: '2024-06-01T14:58:46.388Z'
+        expires: '2024-19-01T14:58:46.388Z'
     - hof > browserify > module-deps > detective > minimist:
         reason: Need to update browserify in HOF when new version is available.
-        expires: '2024-06-01T14:58:46.388Z'
+        expires: '2024-10-01T14:58:46.388Z'
   SNYK-JS-DICER-2311764:
     - busboy-body-parser > busboy > dicer:
         reason: No update available
-        expires: '2024-04-10T12:21:04.350Z'
+        expires: '2024-10-10T12:21:04.350Z'
   SNYK-JS-AXIOS-6032459:
     - hof > notifications-node-client > axios:
         reason: Need to update notifications-node-client in HOF to version 8.0.0.
-        expires: '2024-07-03T00:00:00.000Z'
+        expires: '2024-10-03T00:00:00.000Z'
   SNYK-JS-AXIOS-6124857:
     - hof > notifications-node-client > axios:
         reason: Need to update notifications-node-client in HOF to version 8.0.0.
-        expires: '2024-07-03T00:00:00.000Z'
+        expires: '2024-10-03T00:00:00.000Z'
   SNYK-JS-AXIOS-6144788:
     - hof > notifications-node-client > axios:
       reason: Need to update notifications-node-client in HOF to version 8.0.0.
-      expires: '2024-07-03T00:00:00.000Z'
+      expires: '2024-10-03T00:00:00.000Z'
   SNYK-JS-INFLIGHT-6095116:
     - '*':
       reason: No update available.
-      expires: '2024-07-03T00:00:00.000Z'
+      expires: '2024-10-03T00:00:00.000Z'
   SNYK-JS-MARKDOWNIT-6483324:
     - hof > markdown-it:
       reason: No update available.
-      expires: '2024-07-03T00:00:00.000Z'
+      expires: '2024-10-03T00:00:00.000Z'
+  SNYK-JS-ASYNC-7414156:
+    - hof > winston > async:
+      reason: No update available.
+      expires: '2024-10-03T00:00:00.000Z'
+  SNYK-JS-BRACES-6838727:
+    - hof > chokidar > braces:
+      reason: Need to update braces in HOF to version 3.0.3
+      expires: '2024-10-03T00:00:00.000Z'
+  SNYK-JS-BROWSERIFYSIGN-6037026:
+    - hof > browserify > crypto-browserify> browserify-sign
+      reason: Need to update browserify-sign in HOF to version 4.2.2
+      expires: '2024-10-03T00:00:00.000Z'
+  SNYK-JS-DICER-2311764:
+    - busboy-body-parser > busboy > dicer  
+      reason:  No update available.
+      expires: '2024-10-03T00:00:00.000Z'
+  SNYK-JS-FOLLOWREDIRECTS-6141137:
+    - notifications-node-client > axios > follow-redirects
+      reason:   Need to update version 1.15.4
+      expires: '2024-8-03T00:00:00.000Z'
+  SNYK-JS-FOLLOWREDIRECTS-6444610:
+    - notifications-node-client > axios > follow-redirects
+      reason:   Need to update version 1.15.6
+      expires: '2024-8-03T00:00:00.000Z'
+  SNYK-JS-NODEMAILER-6219989:
+    - hof > nodemailer
+      reason: Need to update nodemailer in HOF to version 6.9.9
+      expires: '2024-10-03T00:00:00.000Z'
+  SNYK-JS-REQUEST-3361831:
+    - hof > request
+      reason: No update available.
+      expires: '2024-10-03T00:00:00.000Z'
+  SNYK-JS-TOUGHCOOKIE-5672873:
+    - hof > request > tough-cookie
+      reason: Need to update tough-cookie in HOF to version 4.1.9
+      expires: '2024-10-03T00:00:00.000Z'
+  SNYK-JS-UNDERSCORE-1080984:
+    - hof > nodemailer-smtp-transport > smtp-connection > httpntlm > underscore
+      reason: Need to update underscore in HOF to version 1.13.0-2, 1.12.1
+      expires: '2024-10-03T00:00:00.000Z'
 patch: {}

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -29,6 +29,7 @@ if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
 elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml  -f kube/app/service.yml
   $kd -f kube/app/ingress-external.yml -f kube/app/networkpolicy-external.yml
+  $kd -f kube/app/ingress-internal.yml
   $kd -f kube/redis -f kube/html-pdf -f kube/file-vault -f kube/app/deployment.yml
 elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml  -f kube/app/service.yml

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -29,7 +29,7 @@ if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
 elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml  -f kube/app/service.yml
   $kd -f kube/app/ingress-external.yml -f kube/app/networkpolicy-external.yml
-  $kd -f kube/app/ingress-internal.yml
+  $kd -f kube/app/ingress-internal.yml -f kube/app/networkpolicy-internal.yml
   $kd -f kube/redis -f kube/html-pdf -f kube/file-vault -f kube/app/deployment.yml
 elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml  -f kube/app/service.yml


### PR DESCRIPTION
### **What?**

* Add the missing Internal Ingress 
* Add the Network Policies for Internal Ingress
* We are deploying Internal ingress for the first time for testers.
* We added Internal ingress annotations in hof-services-config

### **Why?**

* Internal ingress is used by Testers as it can be accessed via kube_vpn 
* Testers will use this Internal ingress currently and in future to run automated tests (performance Tests)

### **How?**
* deploy scripts deploy the kubernetes objects to namespace
* We are now deploying internal ingress and network policies with these scripts to UAT env




### **Testing?**