### PR TITLE
HOFF-2093: update file vault image to latest and patching lodash

### DIFF
--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -41,8 +41,8 @@ spec:
     spec:
       containers:
         - name: file-vault
-          # v3.0.1 28th August 2025
-          image: quay.io/ukhomeofficedigital/file-vault:3.0.1@sha256:44f35820701981eeb3371d332e6fd53f697e1bcd60f75731a57e8da6edb7bed5
+          # v3.1.0 May 2026
+          image: quay.io/ukhomeofficedigital/file-vault:3.1.0@sha256:3f76246641a29bed0ae1289b2d61a698725b9f79c41e72040c7708a652b5a91d
           imagePullPolicy: Always
           resources:
             requests:

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "i18n-lookup": "^1.0.0",
     "is-pdf": "^1.0.0",
     "jquery": "^3.3.1",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.0",
     "moment": "^2.29.4",
     "mustache": "^4.2.0",
     "notifications-node-client": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4205,6 +4205,11 @@ lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+lodash@^4.18.0:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
+
 log-symbols@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"


### PR DESCRIPTION
## What? 

This PR updates the file-vault image to the latest, which contains the critical axios fixes and aws sdk upgrade.

## Why? 

To fix axios vulnerabilities and upgrade aws sdk.

## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
