### PR TITLE
FIREARMS-290: Update html-pdf-converter to Alpine-based Node 24 image with High/Critical CVE fixes

### DIFF
--- a/kube/html-pdf/html-pdf-deployment.yml
+++ b/kube/html-pdf/html-pdf-deployment.yml
@@ -37,8 +37,8 @@ spec:
         {{ else }}
         - name: html-pdf-converter
         {{ end }}
-          # html-pdf-converter: v3.0.0 updated on 23/01/2024
-          image: quay.io/ukhomeofficedigital/html-pdf-converter:3.0.0@sha256:2f13eb3bc9d396f2685e22a66b40613a44dfd9956412fe2752477601bb33772c
+          # html-pdf-converter: v3.1.0 updated on 27/07/2026
+          image: quay.io/ukhomeofficedigital/html-pdf-converter:3.1.0@sha256:42b150c3c441f72ea5d4dc50673fb82e47b1705652bcf62c9b48836e3f70f8ed
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
**What?**

- Updated html-pdf-converter image references under kube/ to:
  quay.io/ukhomeofficedigital/html-pdf-converter:3.1.0@sha256:42b150c3c441f72ea5d4dc50673fb82e47b1705652bcf62c9b48836e3f70f8ed

**Why?**
- The previous Ubuntu-based image had unresolved High/Critical CVEs due to missing upstream patches.
- Alpine-based Node v24 aligns with HOF baseline and security expectations.

**How?**
- Updated image references in kube manifests only.
- No application code changes; deployment behavior is expected to remain unchanged.